### PR TITLE
Sort the enums in a stable manner

### DIFF
--- a/auto/bin/make.pl
+++ b/auto/bin/make.pl
@@ -156,7 +156,11 @@ sub output_tokens($$)
                     if (${$tbl}{$b} =~ /_/) {
                         1
                     } else {
-                        hex ${$tbl}{$a} <=> hex ${$tbl}{$b}
+                        if (hex ${$tbl}{$a} eq hex ${$tbl}{$b}) {
+                            $a cmp $b
+                        } else {
+                            hex ${$tbl}{$a} <=> hex ${$tbl}{$b}
+                        }
                     }                    
                 }
             }


### PR DESCRIPTION
Order of enums generated by function `output_tokens` is unstable

I found this commit (https://github.com/nigels-com/glew/commit/3739be33b026df7de070fc08ed48366b6dafa236) changes `auto/bin/make.pl` and `auto/bin/parse_spec.pl`
but other commit (https://github.com/nigels-com/glew/commit/d04fd20cecd015ec2bfdf44230aef5151dc60248) changes only `auto/bin/parse_spec.pl`

I applied same compare logic to `output_tokens`
