### PR TITLE
Fixed update_ext.sh for cygwin, also added gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 *			eol=lf
 *.png		binary
-build/*		binary
+build/*		eol=crlf


### PR DESCRIPTION
Cygwin was unable to filter the specs files using the blacklist due to
the argument in find was -name _.txt instead of -name "_.txt" .

Also, it is currently possible to pull under windows to result in CRLF
line endings in scripts and other source files that destroy the build.
.gitattributes were added to prevent non-binary pulls.

Both issues are fixed with this pull request.
