### PR TITLE
improved config/Makefile.linux-mingw* to support any host easily

### DIFF
--- a/config/Makefile.linux-mingw32
+++ b/config/Makefile.linux-mingw32
@@ -5,8 +5,9 @@
 #
 
 NAME  := glew32
-CC    := i586-mingw32msvc-gcc
-LD    := i586-mingw32msvc-ld
+HOST  := i586-mingw32msvc
+CC    := $(HOST)-gcc
+LD    := $(HOST)-ld
 LN    :=
 STRIP :=
 LDFLAGS.GL = -lopengl32 -lgdi32 -luser32 -lkernel32

--- a/config/Makefile.linux-mingw64
+++ b/config/Makefile.linux-mingw64
@@ -5,8 +5,9 @@
 #
 
 NAME  := glew32
-CC    := i686-w64-mingw32-gcc
-LD    := i686-w64-mingw32-ld
+HOST  := i686-w64-mingw32
+CC    := $(HOST)-gcc
+LD    := $(HOST)-ld
 LN    :=
 STRIP :=
 LDFLAGS.GL = -lopengl32 -lgdi32 -luser32 -lkernel32


### PR DESCRIPTION
Hi, some days ago I tried to build GLEW for my Linux MinGW environment.
I think you already know, gcc has many patterns of prefix, for example "i386-mingw32msvc" "i586-pc-mingw32" "i686-w64-mingw32". And I useing "i686-pc-mingw32" then I forced CC and LD when make, but I think it is not smart.
Then, I edited config file to fix it.
If you will to add this to your project, I'll be grad to contribute.
