### PR TITLE
Corrected package_config file.

### DIFF
--- a/glew.pc.in
+++ b/glew.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=@libdir@
 includedir=${prefix}/include/GL
 
 Name: glew


### PR DESCRIPTION
On multiarch the librarys got installed in lib64.
Therefore take the libpath from the makefile and not assuming the
lib directory from the install dir