### PR TITLE
Fix extension detection on core contexts.

### DIFF
--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -6,7 +6,9 @@
 #  include <GL/glxew.h>
 #endif
 
+#include <alloca.h>
 #include <stddef.h>  /* For size_t */
+#include <string.h>
 
 /*
  * Define glewGetContext and related helper macros.

--- a/auto/src/glew_init_gl.c
+++ b/auto/src/glew_init_gl.c
@@ -5,8 +5,22 @@ GLboolean GLEWAPIENTRY glewGetExtension (const char* name)
   const GLubyte* start;
   const GLubyte* end;
   start = (const GLubyte*)glGetString(GL_EXTENSIONS);
-  if (start == 0)
+  if (start == 0) {
+    /* no extension string, we're probably on a core context
+       query extensions one at a time */
+    GLint numExtensions = 0;
+    int i;
+    glGetIntegerv(GL_NUM_EXTENSIONS, &numExtensions);
+    /* glewContextInit should have initialized glGetStringi for us */
+    for (i = 0; i < numExtensions; i++) {
+      const GLubyte* extName = glGetStringi(GL_EXTENSIONS, i);
+      GLuint len = _glewStrLen(extName);
+      if (_glewStrSame((const GLubyte*) name, extName, len)) {
+        return GL_TRUE;
+      }
+    }
     return GL_FALSE;
+  }
   end = start + _glewStrLen(start);
   return _glewSearchExtension(name, start, end);
 }

--- a/auto/src/glew_init_gl.c
+++ b/auto/src/glew_init_gl.c
@@ -66,8 +66,44 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
 
   /* query opengl extensions string */
   extStart = glGetString(GL_EXTENSIONS);
-  if (extStart == 0)
-    extStart = (const GLubyte*)"";
+  if (extStart == 0) {
+    /* no extension string, we're probably on a core context
+       build it manually */
+    GLint numExtensions = 0;
+    glGetIntegerv(GL_NUM_EXTENSIONS, &numExtensions);
+    /* don't have real glGetStringi yet... */
+    PFNGLGETSTRINGIPROC tempGetStringi = (PFNGLGETSTRINGIPROC)glewGetProcAddress((const GLubyte*)"glGetStringi");
+    if (numExtensions != 0 && tempGetStringi != 0)
+    {
+      int i;
+      size_t extStrLen = 0;
+      char *extStringTemp;
+      /* calculate length */
+      for (i = 0; i < numExtensions; i++)
+      {
+        const GLubyte* extName = tempGetStringi(GL_EXTENSIONS, i);
+        /* +1 is for space separator */
+        extStrLen += _glewStrLen(extName) + 1;
+      }
+
+      /* need one extra for the '\0' -terminator */
+      extStrLen += 1;
+
+      /* allocate extension string on the stack */
+      extStringTemp = alloca(extStrLen);
+      memset(extStringTemp, 0, extStrLen);
+      extStart = (const GLubyte *) extStringTemp;
+      for (i = 0; i < numExtensions; i++)
+      {
+        const GLubyte* extName = tempGetStringi(GL_EXTENSIONS, i);
+        strcat(extStringTemp, (const char *) extName);
+        /* be efficient, avoid O(n^2) behavior */
+        extStringTemp += _glewStrLen(extName);
+        strcat(extStringTemp, " ");
+        extStringTemp += 1;
+      }
+    }
+  }
   extEnd = extStart + _glewStrLen(extStart);
 
   /* initialize extensions */


### PR DESCRIPTION
This fixes a longstanding issue where GLEW is completely broken on core contexts because glGetString(GL_EXTENSIONS) is no longer valid. When this happens build the string manually.

Tested on 64-bit Linux.

Quick test program for SDL2: http://pastebin.com/KP13Haby