### PR TITLE
OSMesa support

### DIFF
--- a/auto/Makefile
+++ b/auto/Makefile
@@ -200,7 +200,8 @@ $(S.DEST)/glew.c: $(EXT)/.dummy
 	$(BIN)/make_list.pl $(GL_CORE_SPEC) | grep -v '\"GL_VERSION' >> $@
 	$(BIN)/make_list.pl $(GL_EXT_SPEC) >> $@
 	echo -e "\n  return GLEW_OK;\n}\n" >> $@
-	echo -e "\n#if defined(_WIN32)" >> $@
+	echo -e "\n#if defined(GLEW_OSMESA)" >> $@
+	echo -e "\n#elif defined(_WIN32)" >> $@
 	echo -e "\n#if !defined(GLEW_MX)" >> $@
 	$(BIN)/make_def_fun.pl WGL $(WGL_EXT_SPEC) >> $@
 	$(BIN)/make_def_var.pl WGL $(WGL_EXT_SPEC) >> $@
@@ -250,7 +251,8 @@ $(S.DEST)/glew_def.c: $(EXT)/.dummy
 	echo -e "\n#if !defined(GLEW_MX)\n\nGLboolean __GLEW_VERSION_1_1 = GL_FALSE;" >> $@
 	$(BIN)/make_def_var.pl GL $(GL_CORE_SPEC) >> $@
 	$(BIN)/make_def_var.pl GL $(GL_EXT_SPEC) >> $@
-	echo -e "\n#if defined(_WIN32)" >> $@
+	echo -e "\n#if defined(GLEW_OSMESA)" >> $@
+	echo -e "\n#elif defined(_WIN32)" >> $@
 	$(BIN)/make_def_fun.pl WGL $(WGL_EXT_SPEC) >> $@
 	$(BIN)/make_def_var.pl WGL $(WGL_EXT_SPEC) >> $@
 	echo -e "\n#endif /* _WIN32 */" >> $@

--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -1,6 +1,9 @@
 #include <GL/glew.h>
 
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
+#  define GLAPI extern
+#  include <GL/osmesa.h>
+#elif defined(_WIN32)
 #  include <GL/wglew.h>
 #elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && (!defined(__APPLE__) || defined(GLEW_APPLE_GLX))
 #  include <GL/glxew.h>
@@ -137,7 +140,9 @@ void* NSGLGetProcAddress (const GLubyte *name)
 /*
  * Define glewGetProcAddress.
  */
-#if defined(GLEW_REGAL)
+#if defined(GLEW_OSMESA)
+#  define glewGetProcAddress(name) OSMesaGetProcAddress((const char *)name)
+#elif defined(GLEW_REGAL)
 #  define glewGetProcAddress(name) regalGetProcAddress((const GLchar *) name)
 #elif defined(_WIN32)
 #  define glewGetProcAddress(name) wglGetProcAddress((LPCSTR)name)

--- a/auto/src/glew_init_tail.c
+++ b/auto/src/glew_init_tail.c
@@ -34,7 +34,8 @@ GLboolean glewExperimental = GL_FALSE;
 
 #if !defined(GLEW_MX)
 
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
+#elif defined(_WIN32)
 extern GLenum GLEWAPIENTRY wglewContextInit (void);
 #elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && (!defined(__APPLE__) || defined(GLEW_APPLE_GLX))
 extern GLenum GLEWAPIENTRY glxewContextInit (void);
@@ -45,7 +46,9 @@ GLenum GLEWAPIENTRY glewInit (void)
   GLenum r;
   r = glewContextInit();
   if ( r != 0 ) return r;
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
+  return r;
+#elif defined(_WIN32)
   return wglewContextInit();
 #elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && (!defined(__APPLE__) || defined(GLEW_APPLE_GLX)) /* _UNIX */
   return glxewContextInit();

--- a/auto/src/glew_str_wgl.c
+++ b/auto/src/glew_str_wgl.c
@@ -4,7 +4,8 @@
   return ret;
 }
 
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
+#elif defined(_WIN32)
 
 #if defined(GLEW_MX)
 GLboolean GLEWAPIENTRY wglewContextIsSupported (const WGLEWContext* ctx, const char* name)

--- a/auto/src/glew_utils.c
+++ b/auto/src/glew_utils.c
@@ -30,7 +30,10 @@
 */
 
 #include <GL/glew.h>
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
+#  define GLAPI extern
+#  include <GL/osmesa.h>
+#elif defined(_WIN32)
 #  include <GL/wglew.h>
 #elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && (!defined(__APPLE__) || defined(GLEW_APPLE_GLX))
 #  include <GL/glxew.h>

--- a/auto/src/glewinfo_head.c
+++ b/auto/src/glewinfo_head.c
@@ -2,7 +2,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <GL/glew.h>
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
+#define GLAPI extern
+#include <GL/osmesa.h>
+#elif defined(_WIN32)
 #include <GL/wglew.h>
 #elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
 #include <GL/glxew.h>
@@ -17,7 +20,8 @@ static FILE* f;
 #ifdef GLEW_MX
 GLEWContext _glewctx;
 #define glewGetContext() (&_glewctx)
-#ifdef _WIN32
+#if defined(GLEW_OSMESA)
+#elif defined(_WIN32)
 WGLEWContext _wglewctx;
 #define wglewGetContext() (&_wglewctx)
 #elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
@@ -26,7 +30,9 @@ GLXEWContext _glxewctx;
 #endif
 #endif
 
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
+GLboolean glewCreateContext ();
+#elif defined(_WIN32)
 GLboolean glewCreateContext (int* pixelformat);
 #elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
 GLboolean glewCreateContext (const char* display, int* visual);
@@ -34,7 +40,7 @@ GLboolean glewCreateContext (const char* display, int* visual);
 GLboolean glewCreateContext ();
 #endif
 
-#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
+#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX) || !defined(GLEW_OSMESA)
 GLboolean glewParseArgs (int argc, char** argv, char** display, int* visual);
 #endif
 

--- a/auto/src/glewinfo_tail.c
+++ b/auto/src/glewinfo_tail.c
@@ -4,7 +4,7 @@
 
 /* ------------------------------------------------------------------------ */
 
-#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
+#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX) || !defined(GLEW_OSMESA)
 int main (int argc, char** argv)
 #else
 int main (void)
@@ -12,7 +12,7 @@ int main (void)
 {
   GLuint err;
 
-#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
+#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX) || !defined(GLEW_OSMESA)
   char* display = NULL;
   int visual = -1;
 
@@ -27,7 +27,9 @@ int main (void)
   }
 #endif
 
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
+  if (GL_TRUE == glewCreateContext())
+#elif defined(_WIN32)
   if (GL_TRUE == glewCreateContext(&visual))
 #elif defined(__APPLE__) && !defined(GLEW_APPLE_GLX)
   if (GL_TRUE == glewCreateContext())
@@ -44,7 +46,7 @@ int main (void)
   err = glewContextInit(glewGetContext());
 #ifdef _WIN32
   err = err || wglewContextInit(wglewGetContext());
-#elif !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
+#elif !defined(__APPLE__) || defined(GLEW_APPLE_GLX) || !defined(GLEW_OSMESA)
   err = err || glxewContextInit(glxewGetContext());
 #endif
 
@@ -74,7 +76,7 @@ int main (void)
   fprintf(f, "GLEW version %s\n", glewGetString(GLEW_VERSION));
 #if defined(_WIN32)
   fprintf(f, "Reporting capabilities of pixelformat %d\n", visual);
-#elif !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
+#elif !defined(__APPLE__) || defined(GLEW_APPLE_GLX) || !defined(GLEW_OSMESA)
   fprintf(f, "Reporting capabilities of display %s, visual 0x%x\n", 
     display == NULL ? getenv("DISPLAY") : display, visual);
 #endif
@@ -82,7 +84,8 @@ int main (void)
 	  glGetString(GL_RENDERER), glGetString(GL_VENDOR));
   fprintf(f, "OpenGL version %s is supported\n", glGetString(GL_VERSION));
   glewInfo();
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
+#elif defined(_WIN32)
   wglewInfo();
 #else
   glxewInfo();
@@ -94,7 +97,7 @@ int main (void)
 
 /* ------------------------------------------------------------------------ */
 
-#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
+#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX) || !defined(GLEW_OSMESA)
 GLboolean glewParseArgs (int argc, char** argv, char** display, int* visual)
 {
   int p = 0;
@@ -130,7 +133,22 @@ GLboolean glewParseArgs (int argc, char** argv, char** display, int* visual)
 
 /* ------------------------------------------------------------------------ */
 
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
+OSMesaContext ctx;
+
+GLboolean glewCreateContext ()
+{
+  ctx = OSMesaCreateContext(OSMESA_RGBA, NULL);
+  if (NULL == ctx) return GL_TRUE;
+  return GL_FALSE;
+}
+
+void glewDestroyContext ()
+{
+  if (NULL != ctx) OSMesaDestroyContext(ctx);
+}
+
+#elif defined(_WIN32)
 
 HWND wnd = NULL;
 HDC dc = NULL;

--- a/auto/src/glewinfo_wgl.c
+++ b/auto/src/glewinfo_wgl.c
@@ -2,7 +2,8 @@
 
 /* ------------------------------------------------------------------------ */
 
-#ifdef _WIN32
+#if defined(GLEW_OSMESA)
+#elif defined(_WIN32)
 
 static void wglewInfo ()
 {

--- a/config/Makefile.linux-osmesa
+++ b/config/Makefile.linux-osmesa
@@ -1,0 +1,36 @@
+NAME = $(GLEW_NAME)
+CC = cc
+LD = cc
+M_ARCH ?= $(shell uname -m)
+ARCH64 = false
+ifeq (x86_64,${M_ARCH})
+  ARCH64 = true
+endif
+ifeq (ppc64,${M_ARCH})
+  ARCH64 = true
+endif
+ifeq (${ARCH64},true)
+  LDFLAGS.EXTRA = -L/usr/lib64
+  LIBDIR = $(GLEW_DEST)/lib64
+else
+  LDFLAGS.EXTRA = -L/usr/lib
+  LIBDIR = $(GLEW_DEST)/lib
+endif
+LDFLAGS.GL = -lOSMesa
+LDFLAGS.STATIC = -Wl,-Bstatic
+LDFLAGS.DYNAMIC = -Wl,-Bdynamic
+NAME = GLEW
+WARN = -Wall -W
+POPT = -O2
+CFLAGS.EXTRA += -fPIC -DGLEW_OSMESA
+BIN.SUFFIX =
+LIB.SONAME = lib$(NAME).so.$(SO_MAJOR)
+LIB.DEVLNK = lib$(NAME).so
+LIB.SHARED = lib$(NAME).so.$(SO_VERSION)
+LIB.STATIC = lib$(NAME).a
+LDFLAGS.SO = -shared -Wl,-soname=$(LIB.SONAME)
+LIB.SONAME.MX = lib$(NAME)mx.so.$(SO_MAJOR)
+LIB.DEVLNK.MX = lib$(NAME)mx.so
+LIB.SHARED.MX = lib$(NAME)mx.so.$(SO_VERSION)
+LIB.STATIC.MX = lib$(NAME)mx.a
+LDFLAGS.SO.MX = -shared -Wl,-soname=$(LIB.SONAME.MX)


### PR DESCRIPTION
I'm opening this pull request more to start a dialog about how to do this properly than to submit these changes, which are just a hack that has been useful for my purposes.

Mostly this is quick, "do nothing" ifdefs when built with `SYSTEM=linux-osmesa`, to support the off-screen rendering mode of Mesa in headless tests.  Support in glewinfo and visualinfo is enough to get them compile, but insufficient for them to run successfully.

I've been using this for headless testing of a project using glew for almost a year now.