### PR TITLE
add missing glGetGraphicsResetStatus function to VERSION_4_5

### DIFF
--- a/auto/core/gl/GL_VERSION_4_5
+++ b/auto/core/gl/GL_VERSION_4_5
@@ -1,2 +1,4 @@
 GL_VERSION_4_5
 https://www.opengl.org/registry/doc/glspec45.compatibility.pdf
+GL_VERSION_4_5
+    GLenum glGetGraphicsResetStatus (void)


### PR DESCRIPTION
This function is in OpenGL 4.5, but not part of GL_KHR_robustness extension - it is in GL_ARB_robustness, but there it has the ARB suffix.
This trips up OGLplus (https://github.com/matus-chochlik/oglplus) which expects glGetGraphicsResetStatus (no suffix) in the global namespace if GL_VERSION_4_5 is defined.

I'm not sure if this is the correct place to fix it, but the generated code looks plausible to me.