### PR TITLE
Core gl context

### DIFF
--- a/auto/Makefile
+++ b/auto/Makefile
@@ -140,6 +140,7 @@ $(I.DEST)/glew.h: $(EXT)/.dummy
 	echo -e "#if defined(GLEW_MX) && defined(_WIN32)\nstruct GLEWContextStruct\n{\n#endif /* GLEW_MX */" >> $@
 	$(BIN)/make_struct_fun.pl GLEW_FUN_EXPORT $(GL_CORE_SPEC) $(GL_EXT_SPEC) >> $@
 	echo -e "\n#if defined(GLEW_MX) && !defined(_WIN32)\nstruct GLEWContextStruct\n{\n#endif /* GLEW_MX */\n" >> $@
+	echo -e "\n#if defined(GLEW_MX)\nGLEWHashList *GLEW_GL_EXTENSIONS;\n#endif /* GLEW_MX */\n" >> $@
 	$(BIN)/make_struct_var.pl GLEW_VAR_EXPORT $(GL_CORE_SPEC) $(GL_EXT_SPEC) >> $@
 	echo -e "\n#ifdef GLEW_MX\n}; /* GLEWContextStruct */\n#endif /* GLEW_MX */\n" >> $@
 	perl -e "s/GLEW_VAR_EXPORT GLboolean __GLEW_VERSION_1_2;/GLEW_VAR_EXPORT GLboolean __GLEW_VERSION_1_1;\nGLEW_VAR_EXPORT GLboolean __GLEW_VERSION_1_2;/" -pi $@
@@ -157,6 +158,7 @@ $(I.DEST)/wglew.h: $(EXT)/.dummy
 	cat $(SRC)/wglew_mid.h >> $@
 	echo -e "\n#ifdef GLEW_MX\nstruct WGLEWContextStruct\n{\n#endif /* GLEW_MX */" >> $@
 	$(BIN)/make_struct_fun.pl WGLEW_FUN_EXPORT $(WGL_EXT_SPEC) >> $@
+	echo -e "\n#if defined(GLEW_MX)\nGLEWHashList *GLEW_WGL_EXTENSIONS;\n#endif /* GLEW_MX */\n" >> $@
 	$(BIN)/make_struct_var.pl WGLEW_VAR_EXPORT $(WGL_EXT_SPEC) >> $@
 	echo -e "\n#ifdef GLEW_MX\n}; /* WGLEWContextStruct */\n#endif /* GLEW_MX */\n" >> $@
 	cat $(SRC)/wglew_tail.h >> $@
@@ -174,6 +176,7 @@ $(I.DEST)/glxew.h: $(EXT)/.dummy
 	cat $(SRC)/glxew_mid.h >> $@
 	$(BIN)/make_struct_fun.pl GLXEW_FUN_EXPORT $(GLX_CORE_SPEC) $(GLX_EXT_SPEC) >> $@
 	echo -e "\n#if defined(GLEW_MX)\nstruct GLXEWContextStruct\n{\n#endif /* GLEW_MX */\n" >> $@
+	echo -e "\n#if defined(GLEW_MX)\nGLEWHashList *GLEW_GLX_EXTENSIONS;\n#endif /* GLEW_MX */\n" >> $@
 	$(BIN)/make_struct_var.pl GLXEW_VAR_EXPORT $(GLX_CORE_SPEC) $(GLX_EXT_SPEC) >> $@
 	echo -e "\n#ifdef GLEW_MX\n}; /* GLXEWContextStruct */\n#endif /* GLEW_MX */\n" >> $@
 	perl -e "s/GLXEW_VAR_EXPORT GLboolean __GLXEW_VERSION_1_2;/GLXEW_VAR_EXPORT GLboolean __GLXEW_VERSION_1_0;\nGLXEW_VAR_EXPORT GLboolean __GLXEW_VERSION_1_1;\nGLXEW_VAR_EXPORT GLboolean __GLXEW_VERSION_1_2;/" -pi $@

--- a/auto/bin/make.pl
+++ b/auto/bin/make.pl
@@ -12,6 +12,7 @@ my %regex = (
     function => qr/^(.+) ([a-z][a-z0-9_]*) \((.+)\)$/i, 
     token    => qr/^([A-Z][A-Z0-9_x]*)\s+((?:0x)?[0-9A-Fa-f]+|[A-Z][A-Z0-9_]*)$/,
     type     => qr/^typedef\s+(.+)$/,
+    loadexts => qr/^LOAD (.*)$/,
     exact    => qr/.*;$/,
 );
 
@@ -71,6 +72,7 @@ sub parse_ext($)
     my %tokens = ();
     my @types = ();
     my @exacts = ();
+    my @loadexts = ();
     my $extname = "";    # Full extension name GL_FOO_extension
     my $exturl = "";     # Info URL
     my $extstring = "";  # Relevant extension string 
@@ -104,7 +106,11 @@ sub parse_ext($)
         chomp;
         if (s/^\s+//)
         {
-            if (/$regex{exact}/)
+            if (/$regex{loadexts}/)
+            {
+                push @loadexts, $1;
+            }
+            elsif (/$regex{exact}/)
             {
                 push @exacts, $_;
             }
@@ -132,7 +138,7 @@ sub parse_ext($)
 
     close EXT;
 
-    return ($extname, $exturl, $extstring, \@types, \%tokens, \%functions, \@exacts);
+    return ($extname, $exturl, $extstring, \@types, \%tokens, \%functions, \@exacts, \@loadexts);
 }
 
 sub output_tokens($$)
@@ -207,3 +213,14 @@ sub output_exacts($$)
     }
 }
 
+sub output_loadexts($$)
+{
+    my ($tbl, $fnc) = @_;
+    if (scalar @{$tbl})
+    {
+        local $, = "\n";
+        print "\n";
+        print map { &{$fnc}($_) } sort @{$tbl};
+        print "\n";
+    }
+}

--- a/auto/bin/make_def_fun.pl
+++ b/auto/bin/make_def_fun.pl
@@ -29,7 +29,7 @@ if (@ARGV)
 
 	foreach my $ext (sort @extlist)
 	{
-		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts, $loadexts) = parse_ext($ext);
 		output_decls($functions, \&make_pfn_decl);
 	}
 }

--- a/auto/bin/make_def_var.pl
+++ b/auto/bin/make_def_var.pl
@@ -23,7 +23,7 @@ if (@ARGV)
 
 	foreach my $ext (sort @extlist)
 	{
-		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts, $loadexts) = parse_ext($ext);
 		my $extvar = $extname;
 		$extvar =~ s/GL(X*)_/GL$1EW_/;
 		print "GLboolean " . prefix_varname($extvar) . " = GL_FALSE;\n";

--- a/auto/bin/make_header.pl
+++ b/auto/bin/make_header.pl
@@ -52,7 +52,7 @@ if (@ARGV)
 
 	foreach my $ext (sort @extlist)
 	{
-		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts, $loadexts) = parse_ext($ext);
 
 		make_separator($extname);
 		print "#ifndef $extname\n#define $extname 1\n";

--- a/auto/bin/make_html.pl
+++ b/auto/bin/make_html.pl
@@ -26,7 +26,7 @@ if (@ARGV)
 	print "<table border=\"0\" width=\"100%\" cellpadding=\"1\" cellspacing=\"0\" align=\"center\">\n";
 	foreach my $ext (sort @extlist)
 	{
-		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts, $loadexts) = parse_ext($ext);
 		$cur_group = $extname;
 		$cur_group =~ s/^(?:W?)GL(?:X?)_([A-Z0-9]+?)_.*$/$1/;
 		$extname =~ s/^(?:W?)GL(?:X?)_(.*)$/$1/;

--- a/auto/bin/make_info.pl
+++ b/auto/bin/make_info.pl
@@ -32,7 +32,7 @@ if (@ARGV)
 
 	foreach my $ext (sort @extlist)
 	{
-		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts, $loadexts) = parse_ext($ext);
 		my $extvar = $extname;
 		$extvar =~ s/GL(X*)_/GL$1EW_/;
 		my $extpre = $extname;

--- a/auto/bin/make_info_list.pl
+++ b/auto/bin/make_info_list.pl
@@ -38,7 +38,7 @@ if (@ARGV)
 
 	foreach my $ext (sort @extlist)
 	{
-		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts, $loadexts) = parse_ext($ext);
 
 		print "#ifdef $extname\n";
 		print "  _glewInfo_$extname();\n";

--- a/auto/bin/make_init.pl
+++ b/auto/bin/make_init.pl
@@ -21,6 +21,15 @@ sub make_pfn_def_init($%)
     return "  r = ((" . $_[0] . " = (PFN" . (uc $_[0]) . "PROC)glewGetProcAddress((const GLubyte*)\"" . $_[0] . "\")) == NULL) || r;";
 }
 
+sub make_loadexts_forward($%)
+{
+    return "static GLboolean _glewInit_" . $_[0] . "(GLEW_CONTEXT_ARG_DEF_INIT);";
+}
+sub make_loadexts_call($%)
+{
+    return "  r = _glewInit_" . $_[0] . "(GLEW_CONTEXT_ARG_VAR_INIT) || r;";
+}
+
 #-------------------------------------------------------------------------------
 
 my @extlist = ();
@@ -34,7 +43,7 @@ if (@ARGV)
 
 	foreach my $ext (sort @extlist)
 	{
-		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = 
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts, $loadexts) =
 			parse_ext($ext);
 
 		#make_separator($extname);
@@ -42,11 +51,14 @@ if (@ARGV)
 		my $extvar = $extname;
 		my $extvardef = $extname;
 		$extvar =~ s/GL(X*)_/GL$1EW_/;
-		if (keys %$functions)
+		if (keys %$functions or keys @$loadexts)
 		{
-			print "static GLboolean _glewInit_$extname (" . $type . 
+			output_loadexts($loadexts, \&make_loadexts_forward);
+
+			print "static GLboolean _glewInit_$extname (" . $type .
 				"EW_CONTEXT_ARG_DEF_INIT)\n{\n  GLboolean r = GL_FALSE;\n";
 			output_decls($functions, \&make_pfn_def_init);
+			output_loadexts($loadexts, \&make_loadexts_call);
 			print "\n  return r;\n}\n\n";
 		}
 		#print "\nGLboolean " . prefix_varname($extvar) . " = GL_FALSE;\n\n";

--- a/auto/bin/make_list.pl
+++ b/auto/bin/make_list.pl
@@ -32,7 +32,7 @@ if (@ARGV)
 
 	foreach my $ext (sort @extlist)
 	{
-		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts, $loadexts) = parse_ext($ext);
 
 		my $extvar = $extname;
 		$extvar =~ s/GL(X*)_/GL$1EW_/;
@@ -49,7 +49,7 @@ if (@ARGV)
 				print "  " . $extvar . " = _glewHashListExists(ext_hashlist, (const GLubyte *)\"$extstring\");\n";
 		}
 
-		if (keys %$functions)
+		if (keys %$functions or keys @$loadexts)
 		{
 			if ($extname =~ /WGL_.*/)
 			{

--- a/auto/bin/make_list.pl
+++ b/auto/bin/make_list.pl
@@ -46,7 +46,7 @@ if (@ARGV)
 
 		if (length($extstring))
 		{
-				print "  " . $extvar . " = _glewSearchExtension(\"$extstring\", extStart, extEnd);\n";
+				print "  " . $extvar . " = _glewHashListExists(ext_hashlist, (const GLubyte *)\"$extstring\");\n";
 		}
 
 		if (keys %$functions)

--- a/auto/bin/make_str.pl
+++ b/auto/bin/make_str.pl
@@ -22,7 +22,7 @@ if (@ARGV)
 	my $curexttype = "";
 	foreach my $ext (sort @extlist)
 	{
-		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts, $loadexts) = parse_ext($ext);
 		my $exttype = $extname;
 		$exttype =~ s/(W*?)GL(X*?)_(.*?_)(.*)/$3/;
 		my $extrem = $extname;

--- a/auto/bin/make_struct_fun.pl
+++ b/auto/bin/make_struct_fun.pl
@@ -30,7 +30,7 @@ if (@ARGV)
 
 	foreach my $ext (sort @extlist)
 	{
-		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts, $loadexts) = parse_ext($ext);
 		output_decls($functions, \&make_pfn_decl);
 	}
 }

--- a/auto/bin/make_struct_var.pl
+++ b/auto/bin/make_struct_var.pl
@@ -23,7 +23,7 @@ if (@ARGV)
 
 	foreach my $ext (sort @extlist)
 	{
-		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts, $loadexts) = parse_ext($ext);
 		my $extvar = $extname;
 		$extvar =~ s/GL(X*)_/GL$1EW_/;
 		print $export . " GLboolean " . prefix_varname($extvar) . ";\n";

--- a/auto/core/gl/GL_VERSION_3_0
+++ b/auto/core/gl/GL_VERSION_3_0
@@ -161,3 +161,7 @@ https://www.opengl.org/registry/doc/glspec30.20080923.pdf
 	void glClearBufferfv (GLenum buffer, GLint drawBuffer, const GLfloat* value)
 	void glClearBufferfi (GLenum buffer, GLint drawBuffer, GLfloat depth, GLint stencil)
 	const GLubyte* glGetStringi (GLenum name, GLuint index)
+	LOAD GL_ARB_framebuffer_object
+	LOAD GL_ARB_map_buffer_range
+	LOAD GL_ARB_uniform_buffer_object
+	LOAD GL_ARB_vertex_array_object

--- a/auto/core/gl/GL_VERSION_3_1
+++ b/auto/core/gl/GL_VERSION_3_1
@@ -39,3 +39,4 @@ https://www.opengl.org/registry/doc/glspec31.20090528.pdf
 	void glDrawElementsInstanced (GLenum mode, GLsizei count, GLenum type, const void* indices, GLsizei primcount)
 	void glTexBuffer (GLenum target, GLenum internalFormat, GLuint buffer)
 	void glPrimitiveRestartIndex (GLuint buffer)
+	LOAD GL_ARB_copy_buffer

--- a/auto/core/gl/GL_VERSION_3_2
+++ b/auto/core/gl/GL_VERSION_3_2
@@ -26,3 +26,7 @@ https://www.opengl.org/registry/doc/glspec32.compatibility.20091207.pdf
 	void glGetInteger64i_v (GLenum pname, GLuint index, GLint64 * data)
 	void glGetBufferParameteri64v (GLenum target, GLenum value, GLint64 * data)
 	void glFramebufferTexture (GLenum target, GLenum attachment, GLuint texture, GLint level)
+	LOAD GL_ARB_draw_elements_base_vertex
+	LOAD GL_ARB_provoking_vertex
+	LOAD GL_ARB_sync
+	LOAD GL_ARB_texture_multisample

--- a/auto/src/glew_head.h
+++ b/auto/src/glew_head.h
@@ -188,6 +188,8 @@ typedef _W64 int ptrdiff_t;
 extern "C" {
 #endif
 
+typedef struct GLEWHashListStruct GLEWHashList;
+
 /* ----------------------------- GL_VERSION_1_1 ---------------------------- */
 
 #ifndef GL_VERSION_1_1

--- a/auto/src/glew_init_glx.c
+++ b/auto/src/glew_init_glx.c
@@ -1,22 +1,18 @@
 /* ------------------------------------------------------------------------ */
 
 GLboolean glxewGetExtension (const char* name)
-{    
-  const GLubyte* start;
-  const GLubyte* end;
-
-  if (glXGetCurrentDisplay == NULL) return GL_FALSE;
-  start = (const GLubyte*)glXGetClientString(glXGetCurrentDisplay(), GLX_EXTENSIONS);
-  if (0 == start) return GL_FALSE;
-  end = start + _glewStrLen(start);
-  return _glewSearchExtension(name, start, end);
+{
+#if GLEW_MX
+    GLXEWContext *ctx = glxewGetContext();
+#endif
+  return _glewHashListExists(GLXEW_GET_VAR(GLEW_GLX_EXTENSIONS), name);
 }
 
 GLenum glxewContextInit (GLXEW_CONTEXT_ARG_DEF_LIST)
 {
   int major, minor;
-  const GLubyte* extStart;
-  const GLubyte* extEnd;
+  const GLubyte* extensions;
+  GLEWHashList *ext_hashlist;
   /* initialize core GLX 1.2 */
   if (_glewInit_GLX_VERSION_1_2(GLEW_CONTEXT_ARG_VAR_INIT)) return GLEW_ERROR_GLX_VERSION_11_ONLY;
   /* initialize flags */
@@ -44,10 +40,11 @@ GLenum glxewContextInit (GLXEW_CONTEXT_ARG_DEF_LIST)
     }
   }
   /* query GLX extension string */
-  extStart = 0;
-  if (glXGetCurrentDisplay != NULL)
-    extStart = (const GLubyte*)glXGetClientString(glXGetCurrentDisplay(), GLX_EXTENSIONS);
-  if (extStart == 0)
-    extStart = (const GLubyte *)"";
-  extEnd = extStart + _glewStrLen(extStart);
+  GLXEW_GET_VAR(GLEW_GLX_EXTENSIONS) = calloc(1, sizeof(GLEWHashList));
+
+  ext_hashlist = GLXEW_GET_VAR(GLEW_GLX_EXTENSIONS);
+
+  extensions = (const GLubyte*)glXGetClientString(glXGetCurrentDisplay(), GLX_EXTENSIONS);
+  _glewBuildHashListFromString(extensions, ext_hashlist);
+
   /* initialize extensions */


### PR DESCRIPTION
more complete solution to #24.

1. Takes the base approach of building up a hash list but for all extension lists (GL, GLX, and WGL) so everything is consistent.
2. Then it also handles ensuring the "core" extensions are loaded for a 3.2+ context (as extensions are ONLY presented past 3.2)
3. This also works cleanly with MX builds of glew.

Tested and verified on Windows, OS X and Linux in 2 AAA game titles.