### PR TITLE
glewinfo command-line support for GL context version, profile and flags

### DIFF
--- a/auto/Makefile
+++ b/auto/Makefile
@@ -198,6 +198,10 @@ $(S.DEST)/glew.c: $(EXT)/.dummy
 	$(BIN)/make_def_var.pl GL $(GL_CORE_SPEC) >> $@
 	$(BIN)/make_def_var.pl GL $(GL_EXT_SPEC) >> $@
 	echo -e "\n#endif /* !GLEW_MX */\n" >> $@;
+	echo -e "" >> $@;
+	$(BIN)/make_initd.pl GL $(GL_CORE_SPEC) >> $@
+	$(BIN)/make_initd.pl GL $(GL_EXT_SPEC) >> $@
+	echo -e "" >> $@;
 	$(BIN)/make_init.pl GL $(GL_CORE_SPEC) >> $@
 	$(BIN)/make_init.pl GL $(GL_EXT_SPEC) >> $@
 	cat $(SRC)/glew_init_gl.c >> $@

--- a/auto/Makefile
+++ b/auto/Makefile
@@ -198,7 +198,14 @@ $(S.DEST)/glew.c: $(EXT)/.dummy
 	$(BIN)/make_def_var.pl GL $(GL_CORE_SPEC) >> $@
 	$(BIN)/make_def_var.pl GL $(GL_EXT_SPEC) >> $@
 	echo -e "\n#endif /* !GLEW_MX */\n" >> $@;
-	echo -e "" >> $@;
+	echo -e "\nstatic const char * _glewExtensionLookup[] = {" >> $@;
+	$(BIN)/make_index.pl $(GL_EXT_SPEC) >> $@
+	echo -e "  NULL\n};\n" >> $@;
+	echo -e "\n#if !defined(GLEW_MX)" >> $@;
+	echo -e "\nstatic GLboolean* _glewEnabled[] = {" >> $@;
+	$(BIN)/make_enable_index.pl $(GL_CORE_SPEC) $(GL_EXT_SPEC) >> $@
+	echo -e "  NULL\n};\n" >> $@;
+	echo -e "\n#endif /* !GLEW_MX */\n" >> $@;
 	$(BIN)/make_initd.pl GL $(GL_CORE_SPEC) >> $@
 	$(BIN)/make_initd.pl GL $(GL_EXT_SPEC) >> $@
 	echo -e "" >> $@;

--- a/auto/Makefile
+++ b/auto/Makefile
@@ -199,12 +199,10 @@ $(S.DEST)/glew.c: $(EXT)/.dummy
 	$(BIN)/make_def_var.pl GL $(GL_EXT_SPEC) >> $@
 	echo -e "\n#endif /* !GLEW_MX */\n" >> $@;
 	echo -e "\nstatic const char * _glewExtensionLookup[] = {" >> $@;
-	$(BIN)/make_index.pl $(GL_EXT_SPEC) >> $@
+	$(BIN)/make_index.pl $(GL_CORE_SPEC) $(GL_EXT_SPEC) >> $@
 	echo -e "  NULL\n};\n" >> $@;
 	echo -e "\n#if !defined(GLEW_MX)" >> $@;
-	echo -e "\nstatic GLboolean* _glewEnabled[] = {" >> $@;
 	$(BIN)/make_enable_index.pl $(GL_CORE_SPEC) $(GL_EXT_SPEC) >> $@
-	echo -e "  NULL\n};\n" >> $@;
 	echo -e "\n#endif /* !GLEW_MX */\n" >> $@;
 	$(BIN)/make_initd.pl GL $(GL_CORE_SPEC) >> $@
 	$(BIN)/make_initd.pl GL $(GL_EXT_SPEC) >> $@

--- a/auto/bin/make_def_var.pl
+++ b/auto/bin/make_def_var.pl
@@ -21,11 +21,11 @@ if (@ARGV)
 {
     @extlist = @ARGV;
 
-	foreach my $ext (sort @extlist)
-	{
-		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
-		my $extvar = $extname;
-		$extvar =~ s/GL(X*)_/GL$1EW_/;
-		print "GLboolean " . prefix_varname($extvar) . " = GL_FALSE;\n";
-	}
+    foreach my $ext (sort @extlist)
+    {
+        my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
+        my $extvar = $extname;
+        $extvar =~ s/GL(X*)_/GL$1EW_/;
+        print "GLboolean " . prefix_varname($extvar) . " = GL_FALSE;\n";
+    }
 }

--- a/auto/bin/make_def_var.pl
+++ b/auto/bin/make_def_var.pl
@@ -19,13 +19,13 @@ our $type = shift;
 
 if (@ARGV)
 {
-    @extlist = @ARGV;
+	@extlist = @ARGV;
 
-    foreach my $ext (sort @extlist)
-    {
-        my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
-        my $extvar = $extname;
-        $extvar =~ s/GL(X*)_/GL$1EW_/;
-        print "GLboolean " . prefix_varname($extvar) . " = GL_FALSE;\n";
-    }
+	foreach my $ext (sort @extlist)
+	{
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = parse_ext($ext);
+		my $extvar = $extname;
+		$extvar =~ s/GL(X*)_/GL$1EW_/;
+		print "GLboolean " . prefix_varname($extvar) . " = GL_FALSE;\n";
+	}
 }

--- a/auto/bin/make_enable_index.pl
+++ b/auto/bin/make_enable_index.pl
@@ -20,26 +20,26 @@ my @extlist = ();
 
 if (@ARGV)
 {
-    @extlist = @ARGV;
+	@extlist = @ARGV;
 
-    print "/* Detected in the extension string or strings */\n";
-    print "static GLboolean  _glewExtensionString[" . scalar @extlist . "];\n";
+	print "/* Detected in the extension string or strings */\n";
+	print "static GLboolean  _glewExtensionString[" . scalar @extlist . "];\n";
 
-    print "/* Detected via extension string or experimental mode */\n";
-    print "static GLboolean* _glewExtensionEnabled[] = {\n";;
+	print "/* Detected via extension string or experimental mode */\n";
+	print "static GLboolean* _glewExtensionEnabled[] = {\n";;
 
-    foreach my $ext (sort @extlist)
-    {
-        my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = 
-            parse_ext($ext);
+	foreach my $ext (sort @extlist)
+	{
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = 
+			parse_ext($ext);
 
-        my $extvar = $extname;
-        $extvar =~ s/GL(X*)_/GL$1EW_/;
+		my $extvar = $extname;
+		$extvar =~ s/GL(X*)_/GL$1EW_/;
 
-        print "#ifdef $extname\n";
-        print "  &__$extvar,\n";
-        print "#endif\n";
-    }
+		print "#ifdef $extname\n";
+		print "  &__$extvar,\n";
+		print "#endif\n";
+	}
 
-    print "  NULL\n};\n";
+	print "  NULL\n};\n";
 }

--- a/auto/bin/make_enable_index.pl
+++ b/auto/bin/make_enable_index.pl
@@ -1,0 +1,37 @@
+#!/usr/bin/perl
+##
+## Copyright (C) 2002-2008, Marcelo E. Magallon <mmagallo[]debian org>
+## Copyright (C) 2002-2008, Milan Ikits <milan ikits[]ieee org>
+##
+## This program is distributed under the terms and conditions of the GNU
+## General Public License Version 2 as published by the Free Software
+## Foundation or, at your option, any later version.
+
+use strict;
+use warnings;
+
+do 'bin/make.pl';
+
+##
+## Make Extension-enabled Index
+##
+
+my @extlist = ();
+
+if (@ARGV)
+{
+    @extlist = @ARGV;
+
+    foreach my $ext (sort @extlist)
+    {
+        my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = 
+            parse_ext($ext);
+
+        my $extvar = $extname;
+        $extvar =~ s/GL(X*)_/GL$1EW_/;
+
+        print "#ifdef $extname\n";
+        print "  &__$extvar,\n";
+        print "#endif\n";
+    }
+}

--- a/auto/bin/make_enable_index.pl
+++ b/auto/bin/make_enable_index.pl
@@ -22,6 +22,12 @@ if (@ARGV)
 {
     @extlist = @ARGV;
 
+    print "/* Detected in the extension string or strings */\n";
+    print "static GLboolean  _glewExtensionString[" . scalar @extlist . "];\n";
+
+    print "/* Detected via extension string or experimental mode */\n";
+    print "static GLboolean* _glewExtensionEnabled[] = {\n";;
+
     foreach my $ext (sort @extlist)
     {
         my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = 
@@ -34,4 +40,6 @@ if (@ARGV)
         print "  &__$extvar,\n";
         print "#endif\n";
     }
+
+    print "  NULL\n};\n";
 }

--- a/auto/bin/make_index.pl
+++ b/auto/bin/make_index.pl
@@ -24,15 +24,15 @@ my @extlist = ();
 
 if (@ARGV)
 {
-    @extlist = @ARGV;
+	@extlist = @ARGV;
 
-    foreach my $ext (sort @extlist)
-    {
-        my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = 
-            parse_ext($ext);
+	foreach my $ext (sort @extlist)
+	{
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = 
+			parse_ext($ext);
 
-        print "#ifdef $extname\n";
-        print "  \"$extname\",\n";
-        print "#endif\n";
-    }
+		print "#ifdef $extname\n";
+		print "  \"$extname\",\n";
+		print "#endif\n";
+	}
 }

--- a/auto/bin/make_index.pl
+++ b/auto/bin/make_index.pl
@@ -1,0 +1,38 @@
+#!/usr/bin/perl
+##
+## Copyright (C) 2002-2008, Marcelo E. Magallon <mmagallo[]debian org>
+## Copyright (C) 2002-2008, Milan Ikits <milan ikits[]ieee org>
+##
+## This program is distributed under the terms and conditions of the GNU
+## General Public License Version 2 as published by the Free Software
+## Foundation or, at your option, any later version.
+
+use strict;
+use warnings;
+
+do 'bin/make.pl';
+
+##
+## Make Index
+##
+## Output sorted array of extension strings for indexing into extension
+## enable/disable flags.  This provides a way to convert an extension string
+## into an integer index.
+##
+
+my @extlist = ();
+
+if (@ARGV)
+{
+    @extlist = @ARGV;
+
+    foreach my $ext (sort @extlist)
+    {
+        my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = 
+            parse_ext($ext);
+
+        print "#ifdef $extname\n";
+        print "  \"$extstring\",\n";
+        print "#endif\n";
+    }
+}

--- a/auto/bin/make_index.pl
+++ b/auto/bin/make_index.pl
@@ -32,7 +32,7 @@ if (@ARGV)
             parse_ext($ext);
 
         print "#ifdef $extname\n";
-        print "  \"$extstring\",\n";
+        print "  \"$extname\",\n";
         print "#endif\n";
     }
 }

--- a/auto/bin/make_init.pl
+++ b/auto/bin/make_init.pl
@@ -38,18 +38,17 @@ if (@ARGV)
 			parse_ext($ext);
 
 		#make_separator($extname);
-		print "#ifdef $extname\n\n";
 		my $extvar = $extname;
 		my $extvardef = $extname;
 		$extvar =~ s/GL(X*)_/GL$1EW_/;
 		if (keys %$functions)
 		{
+			print "#ifdef $extname\n\n";
 			print "static GLboolean _glewInit_$extname (" . $type . 
 				"EW_CONTEXT_ARG_DEF_INIT)\n{\n  GLboolean r = GL_FALSE;\n";
 			output_decls($functions, \&make_pfn_def_init);
 			print "\n  return r;\n}\n\n";
+			print "#endif /* $extname */\n\n";
 		}
-		#print "\nGLboolean " . prefix_varname($extvar) . " = GL_FALSE;\n\n";
-		print "#endif /* $extname */\n\n";
 	}
 }

--- a/auto/bin/make_initd.pl
+++ b/auto/bin/make_initd.pl
@@ -1,0 +1,44 @@
+#!/usr/bin/perl
+##
+## Copyright (C) 2002-2008, Marcelo E. Magallon <mmagallo[]debian org>
+## Copyright (C) 2002-2008, Milan Ikits <milan ikits[]ieee org>
+##
+## This program is distributed under the terms and conditions of the GNU
+## General Public License Version 2 as published by the Free Software
+## Foundation or, at your option, any later version.
+
+use strict;
+use warnings;
+
+do 'bin/make.pl';
+
+## Output declarations for the _glewInit_[extension] functions defined
+## by make_init.pl script.  These are necessary for for initializers to
+## call each other, such as a core GL 3 context that depends on certain
+## extensions.
+
+#-------------------------------------------------------------------------------
+
+my @extlist = ();
+my %extensions = ();
+
+our $type = shift;
+
+if (@ARGV)
+{
+    @extlist = @ARGV;
+
+	foreach my $ext (sort @extlist)
+	{
+		my ($extname, $exturl, $extstring, $types, $tokens, $functions, $exacts) = 
+			parse_ext($ext);
+
+		#print "#ifdef $extname\n\n";
+		if (keys %$functions)
+		{
+			print "static GLboolean _glewInit_$extname (" . $type . 
+				"EW_CONTEXT_ARG_DEF_INIT);\n";
+		}
+		#print "#endif /* $extname */\n\n";
+	}
+}

--- a/auto/bin/make_list.pl
+++ b/auto/bin/make_list.pl
@@ -42,15 +42,10 @@ if (@ARGV)
 
 		#my $pextvar = prefix_varname($extvar);
 
-		print "#ifdef $extname\n";
-
-		if (length($extstring))
-		{
-				print "  " . $extvar . " = _glewSearchExtension(\"$extstring\", extStart, extEnd);\n";
-		}
-
 		if (keys %$functions)
 		{
+			print "#ifdef $extname\n";
+
 			if ($extname =~ /WGL_.*/)
 			{
 				print "  if (glewExperimental || " . $extvar . "|| crippled) " . $extvar . "= !_glewInit_$extname(GLEW_CONTEXT_ARG_VAR_INIT);\n";
@@ -59,8 +54,9 @@ if (@ARGV)
 			{
 				print "  if (glewExperimental || " . $extvar . ") " . $extvar . " = !_glewInit_$extname(GLEW_CONTEXT_ARG_VAR_INIT);\n";
 			}
+			
+			print "#endif /* $extname */\n";
 		}
-		print "#endif /* $extname */\n";
 	}
 
 }

--- a/auto/bin/make_list.pl
+++ b/auto/bin/make_list.pl
@@ -42,10 +42,15 @@ if (@ARGV)
 
 		#my $pextvar = prefix_varname($extvar);
 
+		print "#ifdef $extname\n";
+
+		if (length($extstring) && $extstring !~ /^GL_/)
+		{
+				print "  " . $extvar . " = _glewSearchExtension(\"$extstring\", extStart, extEnd);\n";
+		}
+
 		if (keys %$functions)
 		{
-			print "#ifdef $extname\n";
-
 			if ($extname =~ /WGL_.*/)
 			{
 				print "  if (glewExperimental || " . $extvar . "|| crippled) " . $extvar . "= !_glewInit_$extname(GLEW_CONTEXT_ARG_VAR_INIT);\n";
@@ -54,9 +59,8 @@ if (@ARGV)
 			{
 				print "  if (glewExperimental || " . $extvar . ") " . $extvar . " = !_glewInit_$extname(GLEW_CONTEXT_ARG_VAR_INIT);\n";
 			}
-			
-			print "#endif /* $extname */\n";
 		}
+		print "#endif /* $extname */\n";
 	}
 
 }

--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -7,8 +7,6 @@
 #endif
 
 #include <stddef.h>  /* For size_t */
-#include <string.h>  /* memset, etc */
-#include <stdlib.h>
 
 /*
  * Define glewGetContext and related helper macros.
@@ -207,15 +205,21 @@ static GLuint _glewStrCLen (const GLubyte* s, GLubyte c)
 
 static GLubyte *_glewStrDup (const GLubyte *s)
 {
-    int n = _glewStrLen(s) + 1;
-    GLubyte *dup = malloc(n);
+    int n = _glewStrLen(s);
+    GLubyte *dup = malloc(n+1);
     if (dup)
     {
-        strcpy((char *) dup, (const char *) s);
+        GLubyte *i = dup;
+        for (;;)
+        {
+            *i = *s;
+            if (*i) { ++i; ++s; } else break;
+        }
     }
     return dup;
 }
 
+#if !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
 static GLboolean _glewStrSame (const GLubyte* a, const GLubyte* b, GLuint n)
 {
   GLuint i=0;
@@ -224,6 +228,7 @@ static GLboolean _glewStrSame (const GLubyte* a, const GLubyte* b, GLuint n)
   while (i < n && a[i] != '\0' && b[i] != '\0' && a[i] == b[i]) i++;
   return i == n ? GL_TRUE : GL_FALSE;
 }
+#endif
 
 static GLboolean _glewStrSame1 (const GLubyte** a, GLuint* na, const GLubyte* b, GLuint nb)
 {
@@ -284,6 +289,7 @@ static GLboolean _glewStrSame3 (const GLubyte** a, GLuint* na, const GLubyte* b,
  * other extension names. Could use strtok() but the constant
  * string returned by glGetString might be in read-only memory.
  */
+#if !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
 static GLboolean _glewSearchExtension (const char* name, const GLubyte *start, const GLubyte *end)
 {
   const GLubyte* p;
@@ -297,3 +303,4 @@ static GLboolean _glewSearchExtension (const char* name, const GLubyte *start, c
   }
   return GL_FALSE;
 }
+#endif

--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -188,6 +188,7 @@ void* NSGLGetProcAddress (const GLubyte *name)
  * GLEW, just like OpenGL or GLU, does not rely on the standard C library.
  * These functions implement the functionality required in this file.
  */
+
 static GLuint _glewStrLen (const GLubyte* s)
 {
   GLuint i=0;
@@ -202,6 +203,17 @@ static GLuint _glewStrCLen (const GLubyte* s, GLubyte c)
   if (s == NULL) return 0;
   while (s[i] != '\0' && s[i] != c) i++;
   return (s[i] == '\0' || s[i] == c) ? i : 0;
+}
+
+static GLubyte *_glewStrDup (const GLubyte *s)
+{
+    int n = _glewStrLen(s) + 1;
+    GLubyte *dup = malloc(n);
+    if (dup)
+    {
+        strcpy((char *) dup, (const char *) s);
+    }
+    return dup;
 }
 
 static GLboolean _glewStrSame (const GLubyte* a, const GLubyte* b, GLuint n)

--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -202,6 +202,7 @@ static GLuint _glewStrCLen (const GLubyte* s, GLubyte c)
   return (s[i] == '\0' || s[i] == c) ? i : 0;
 }
 
+#if 0
 static GLboolean _glewStrSame (const GLubyte* a, const GLubyte* b, GLuint n)
 {
   GLuint i=0;
@@ -210,6 +211,7 @@ static GLboolean _glewStrSame (const GLubyte* a, const GLubyte* b, GLuint n)
   while (i < n && a[i] != '\0' && b[i] != '\0' && a[i] == b[i]) i++;
   return i == n ? GL_TRUE : GL_FALSE;
 }
+#endif
 
 static GLboolean _glewStrSame1 (const GLubyte** a, GLuint* na, const GLubyte* b, GLuint nb)
 {
@@ -260,26 +262,6 @@ static GLboolean _glewStrSame3 (const GLubyte** a, GLuint* na, const GLubyte* b,
       *na = *na - nb;
       return GL_TRUE;
     }
-  }
-  return GL_FALSE;
-}
-
-/*
- * Search for name in the extensions string. Use of strstr()
- * is not sufficient because extension names can be prefixes of
- * other extension names. Could use strtok() but the constant
- * string returned by glGetString might be in read-only memory.
- */
-static GLboolean _glewSearchExtension (const char* name, const GLubyte *start, const GLubyte *end)
-{
-  const GLubyte* p;
-  GLuint len = _glewStrLen((const GLubyte*)name);
-  p = start;
-  while (p < end)
-  {
-    GLuint n = _glewStrCLen(p, ' ');
-    if (len == n && _glewStrSame((const GLubyte*)name, p, n)) return GL_TRUE;
-    p += n+1;
   }
   return GL_FALSE;
 }

--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -7,6 +7,8 @@
 #endif
 
 #include <stddef.h>  /* For size_t */
+#include <string.h>  /* memset, etc */
+#include <stdlib.h>
 
 /*
  * Define glewGetContext and related helper macros.
@@ -202,7 +204,6 @@ static GLuint _glewStrCLen (const GLubyte* s, GLubyte c)
   return (s[i] == '\0' || s[i] == c) ? i : 0;
 }
 
-#if 0
 static GLboolean _glewStrSame (const GLubyte* a, const GLubyte* b, GLuint n)
 {
   GLuint i=0;
@@ -211,7 +212,6 @@ static GLboolean _glewStrSame (const GLubyte* a, const GLubyte* b, GLuint n)
   while (i < n && a[i] != '\0' && b[i] != '\0' && a[i] == b[i]) i++;
   return i == n ? GL_TRUE : GL_FALSE;
 }
-#endif
 
 static GLboolean _glewStrSame1 (const GLubyte** a, GLuint* na, const GLubyte* b, GLuint nb)
 {
@@ -262,6 +262,26 @@ static GLboolean _glewStrSame3 (const GLubyte** a, GLuint* na, const GLubyte* b,
       *na = *na - nb;
       return GL_TRUE;
     }
+  }
+  return GL_FALSE;
+}
+
+/*
+ * Search for name in the extensions string. Use of strstr()
+ * is not sufficient because extension names can be prefixes of
+ * other extension names. Could use strtok() but the constant
+ * string returned by glGetString might be in read-only memory.
+ */
+static GLboolean _glewSearchExtension (const char* name, const GLubyte *start, const GLubyte *end)
+{
+  const GLubyte* p;
+  GLuint len = _glewStrLen((const GLubyte*)name);
+  p = start;
+  while (p < end)
+  {
+    GLuint n = _glewStrCLen(p, ' ');
+    if (len == n && _glewStrSame((const GLubyte*)name, p, n)) return GL_TRUE;
+    p += n+1;
   }
   return GL_FALSE;
 }

--- a/auto/src/glew_init_gl.c
+++ b/auto/src/glew_init_gl.c
@@ -117,7 +117,30 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
 
   if (GLEW_VERSION_3_0)
   {
-    /* TODO */
+    GLint n = 0;
+    GLint i;
+    PFNGLGETSTRINGIPROC getStringi;
+    const char *ext;
+
+    glGetIntegerv(GL_NUM_EXTENSIONS, &n);
+
+    /* glGetStringi is OpenGL 3.0 */
+    getStringi = (PFNGLGETSTRINGIPROC) glewGetProcAddress((const GLubyte*)"glGetStringi");
+    if (glGetStringi)
+      for (i = 0; i<n; ++i)
+      {
+        ext = (const char *) getStringi(GL_EXTENSIONS, i);
+
+        /* Based on extension string(s), glewGetExtension purposes */
+        enable = _glewGetExtensionString(ext);
+        if (enable)
+          *enable = GL_TRUE;
+
+        /* Based on extension string(s), experimental mode, glewIsSupported purposes */
+        enable = _glewGetExtensionEnable(ext);
+        if (enable)
+          *enable = GL_TRUE;
+      }
   }
   else
   {

--- a/auto/src/glew_init_gl.c
+++ b/auto/src/glew_init_gl.c
@@ -1,14 +1,60 @@
 /* ------------------------------------------------------------------------- */
 
+static int _glewExtensionCompare(const void *a, const void *b)
+{
+   return strcmp((const char *) a, *(const char**) b);
+}
+
+static GLboolean *_glewGetExtensionString(const char *name)
+{
+  const char **n = (const char **) bsearch(name, _glewExtensionLookup, sizeof(_glewExtensionLookup)/sizeof(char *)-1, sizeof(char *), _glewExtensionCompare);
+  int i;
+
+  if (n)
+  {
+      i = n-_glewExtensionLookup;
+      return _glewExtensionString+i;
+  }
+
+  return NULL;
+}
+
+static GLboolean *_glewGetExtensionEnable(const char *name)
+{
+  const char **n = (const char **) bsearch(name, _glewExtensionLookup, sizeof(_glewExtensionLookup)/sizeof(char *)-1, sizeof(char *), _glewExtensionCompare);
+  int i;
+
+  if (n)
+  {
+      i = n-_glewExtensionLookup;
+      return _glewExtensionEnabled[i];
+  }
+
+  return NULL;
+}
+
+static char *_glewNextSpace(char *i)
+{
+  char *j = i;
+  if (j)
+    while (*j!=' ' && *j) ++j;
+  return j;
+}
+
+static char *_glewNextNonSpace(char *i)
+{
+  char *j = i;
+  if (j)
+    while (*j==' ') ++j;
+  return j;
+}
+
 GLboolean GLEWAPIENTRY glewGetExtension (const char* name)
-{    
-  const GLubyte* start;
-  const GLubyte* end;
-  start = (const GLubyte*)glGetString(GL_EXTENSIONS);
-  if (start == 0)
-    return GL_FALSE;
-  end = start + _glewStrLen(start);
-  return _glewSearchExtension(name, start, end);
+{
+  GLboolean *enable = _glewGetExtensionString(name);
+  if (enable)
+    return *enable;
+  return GL_FALSE;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -21,8 +67,12 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
   const GLubyte* s;
   GLuint dot;
   GLint major, minor;
-  const GLubyte* extStart;
-  const GLubyte* extEnd;
+  char *begin;
+  char *end;
+  char *i;
+  char *j;
+  GLboolean *enable;
+
   /* query opengl version */
   s = glGetString(GL_VERSION);
   dot = _glewStrCLen(s, '.');
@@ -37,7 +87,6 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
   if (major<0 || major>9)
     return GLEW_ERROR_NO_GL_VERSION;
   
-
   if (major == 1 && minor == 0)
   {
     return GLEW_ERROR_GL_VERSION_10_ONLY;
@@ -64,10 +113,35 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
     GLEW_VERSION_1_1   = GLEW_VERSION_1_2   == GL_TRUE || ( major == 1 && minor >= 1 ) ? GL_TRUE : GL_FALSE;
   }
 
-  /* query opengl extensions string */
-  extStart = glGetString(GL_EXTENSIONS);
-  if (extStart == 0)
-    extStart = (const GLubyte*)"";
-  extEnd = extStart + _glewStrLen(extStart);
+  memset(_glewExtensionString,0,sizeof(_glewExtensionString));
 
-  /* initialize extensions */
+  if (GLEW_VERSION_3_0)
+  {
+    /* TODO */
+  }
+  else
+  {
+    begin = (char *) glGetString(GL_EXTENSIONS);
+    if (begin)
+    {
+      begin = strdup(begin);
+      end = begin + strlen(begin);
+      for (i=begin; i<end; i = j + 1)
+      {
+        i = _glewNextNonSpace(i);
+        j = _glewNextSpace(i);
+        *j = 0;
+
+        /* Based on extension string(s), glewGetExtension purposes */
+        enable = _glewGetExtensionString(i);
+        if (enable)
+          *enable = GL_TRUE;
+
+        /* Based on extension string(s), experimental mode, glewIsSupported purposes */
+        enable = _glewGetExtensionEnable(i);
+        if (enable)
+          *enable = GL_TRUE;
+      }
+      free(begin);
+    }
+  }

--- a/auto/src/glew_init_gl.c
+++ b/auto/src/glew_init_gl.c
@@ -140,7 +140,7 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
   }
   else
   {
-    const char *ext;
+    const GLubyte *ext;
     char *begin;
     char *end;
     char *i;
@@ -151,8 +151,8 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
 
     if (ext)
     {
-      begin = strdup(ext);
-      end = begin + strlen(begin);
+      begin = (char *) _glewStrDup(ext);
+      end = begin + _glewStrLen((GLubyte *) begin);
       for (i=begin; i<end; i = j + 1)
       {
         i = _glewNextNonSpace(i);

--- a/auto/src/glew_init_gl.c
+++ b/auto/src/glew_init_gl.c
@@ -2,7 +2,7 @@
 
 static int _glewExtensionCompare(const void *a, const void *b)
 {
-   return strcmp((const char *) a, *(const char**) b);
+   return strcmp((const char *) a, *(const char * const *) b);
 }
 
 static GLboolean *_glewGetExtensionString(const char *name)
@@ -67,11 +67,6 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
   const GLubyte* s;
   GLuint dot;
   GLint major, minor;
-  char *begin;
-  char *end;
-  char *i;
-  char *j;
-  GLboolean *enable;
 
   /* query opengl version */
   s = glGetString(GL_VERSION);
@@ -121,6 +116,7 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
     GLint i;
     PFNGLGETSTRINGIPROC getStringi;
     const char *ext;
+    GLboolean *enable;
 
     glGetIntegerv(GL_NUM_EXTENSIONS, &n);
 
@@ -144,10 +140,18 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
   }
   else
   {
-    begin = (char *) glGetString(GL_EXTENSIONS);
-    if (begin)
+    const char *ext;
+    char *begin;
+    char *end;
+    char *i;
+    char *j;
+    GLboolean *enable;
+
+    ext = (const char *) glGetString(GL_EXTENSIONS);
+
+    if (ext)
     {
-      begin = strdup(begin);
+      begin = strdup(ext);
       end = begin + strlen(begin);
       for (i=begin; i<end; i = j + 1)
       {

--- a/auto/src/glew_init_gl.c
+++ b/auto/src/glew_init_gl.c
@@ -122,7 +122,7 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
 
     /* glGetStringi is OpenGL 3.0 */
     getStringi = (PFNGLGETSTRINGIPROC) glewGetProcAddress((const GLubyte*)"glGetStringi");
-    if (glGetStringi)
+    if (getStringi)
       for (i = 0; i<n; ++i)
       {
         ext = (const char *) getStringi(GL_EXTENSIONS, i);

--- a/auto/src/glew_init_gl.c
+++ b/auto/src/glew_init_gl.c
@@ -147,7 +147,7 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
     char *j;
     GLboolean *enable;
 
-    ext = (const char *) glGetString(GL_EXTENSIONS);
+    ext = glGetString(GL_EXTENSIONS);
 
     if (ext)
     {

--- a/auto/src/glew_utils.c
+++ b/auto/src/glew_utils.c
@@ -87,6 +87,17 @@ void* dlGetProcAddress (const GLubyte* name)
  * These functions implement the functionality required in this file.
  */
 
+static GLubyte *_glewStrDup (const GLubyte *str)
+{
+    int n = strlen(str) + 1;
+    char *dup = malloc(n);
+    if (dup)
+    {
+        strcpy(dup, str);
+    }
+    return dup;
+}
+
 GLuint _glewStrLen (const GLubyte* s)
 {
   GLuint i=0;

--- a/auto/src/glewinfo_head.c
+++ b/auto/src/glewinfo_head.c
@@ -8,6 +8,10 @@
 #include <GL/glxew.h>
 #endif
 
+#if defined(__APPLE__)
+#include <AvailabilityMacros.h>
+#endif
+
 #ifdef GLEW_REGAL
 #include <GL/Regal.h>
 #endif
@@ -40,9 +44,7 @@ struct createParams {
 
 GLboolean glewCreateContext (struct createParams *params);
 
-#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
 GLboolean glewParseArgs (int argc, char** argv, struct createParams *);
-#endif
 
 void glewDestroyContext ();
 

--- a/auto/src/glewinfo_head.c
+++ b/auto/src/glewinfo_head.c
@@ -26,16 +26,22 @@ GLXEWContext _glxewctx;
 #endif
 #endif
 
+struct createParams {
 #if defined(_WIN32)
-GLboolean glewCreateContext (int* pixelformat);
+  int         pixelformat;
 #elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
-GLboolean glewCreateContext (const char* display, int* visual);
-#else
-GLboolean glewCreateContext ();
+  const char* display;
+  int         visual;
 #endif
+  int         major, minor;
+  int         profile_mask;
+  int         flags;
+};
+
+GLboolean glewCreateContext (struct createParams *params);
 
 #if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
-GLboolean glewParseArgs (int argc, char** argv, char** display, int* visual);
+GLboolean glewParseArgs (int argc, char** argv, struct createParams *);
 #endif
 
 void glewDestroyContext ();

--- a/auto/src/glewinfo_tail.c
+++ b/auto/src/glewinfo_tail.c
@@ -11,29 +11,38 @@ int main (void)
 #endif
 {
   GLuint err;
+  struct createParams params = {
+#if defined(_WIN32)
+    -1,  /* pixelformat */
+#elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
+    "",  /* display */
+    -1,  /* visual */
+#endif
+    0,   /* major */
+    0,   /* minor */
+    0,   /* profile mask */
+    0    /* flags */
+  };
 
 #if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
-  char* display = NULL;
-  int visual = -1;
-
-  if (glewParseArgs(argc-1, argv+1, &display, &visual))
+  if (glewParseArgs(argc-1, argv+1, &params))
   {
+    fprintf(stderr, "Usage: glewinfo "
 #if defined(_WIN32)
-    fprintf(stderr, "Usage: glewinfo [-pf <id>]\n");
+	    "[-pf <pixelformat>] "
 #else
-    fprintf(stderr, "Usage: glewinfo [-display <display>] [-visual <id>]\n");
+	    "[-display <display>] "
+	    "[-visual <visual id>] "
 #endif
+	    "[-version <OpenGL version>] "
+	    "[-profiles <OpenGL profile mask>] "
+	    "[-flags <OpenGL flags>]"
+	    "\n");
     return 1;
   }
 #endif
 
-#if defined(_WIN32)
-  if (GL_TRUE == glewCreateContext(&visual))
-#elif defined(__APPLE__) && !defined(GLEW_APPLE_GLX)
-  if (GL_TRUE == glewCreateContext())
-#else
-  if (GL_TRUE == glewCreateContext(display, &visual))
-#endif
+  if (GL_TRUE == glewCreateContext(&params))
   {
     fprintf(stderr, "Error: glewCreateContext failed\n");
     glewDestroyContext();
@@ -73,10 +82,10 @@ int main (void)
   fprintf(f, "---------------------------\n\n");
   fprintf(f, "GLEW version %s\n", glewGetString(GLEW_VERSION));
 #if defined(_WIN32)
-  fprintf(f, "Reporting capabilities of pixelformat %d\n", visual);
+  fprintf(f, "Reporting capabilities of pixelformat %d\n", params.pixelformat);
 #elif !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
   fprintf(f, "Reporting capabilities of display %s, visual 0x%x\n", 
-    display == NULL ? getenv("DISPLAY") : display, visual);
+    params.display == NULL ? getenv("DISPLAY") : params.display, params.visual);
 #endif
   fprintf(f, "Running on a %s from %s\n", 
 	  glGetString(GL_RENDERER), glGetString(GL_VENDOR));
@@ -95,34 +104,46 @@ int main (void)
 /* ------------------------------------------------------------------------ */
 
 #if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
-GLboolean glewParseArgs (int argc, char** argv, char** display, int* visual)
+GLboolean glewParseArgs (int argc, char** argv, struct createParams *params)
 {
   int p = 0;
   while (p < argc)
   {
-#if defined(_WIN32)
-    if (!strcmp(argv[p], "-pf") || !strcmp(argv[p], "-pixelformat"))
+    if (!strcmp(argv[p], "-version"))
     {
       if (++p >= argc) return GL_TRUE;
-      *display = 0;
-      *visual = strtol(argv[p++], NULL, 0);
+      if (sscanf(argv[p++], "%d.%d", &params->major, &params->minor) != 2) return GL_TRUE;
     }
-    else
-      return GL_TRUE;
-#else
-    if (!strcmp(argv[p], "-display"))
+    else if (!strcmp(argv[p], "-profiles"))
     {
       if (++p >= argc) return GL_TRUE;
-      *display = argv[p++];
+      params->profile_mask = (int)strtol(argv[p++], NULL, 0);
+    }
+    else if (!strcmp(argv[p], "-flags"))
+    {
+      if (++p >= argc) return GL_TRUE;
+      params->flags = (int)strtol(argv[p++], NULL, 0);
+    }
+#if defined(_WIN32)
+    else if (!strcmp(argv[p], "-pf") || !strcmp(argv[p], "-pixelformat"))
+    {
+      if (++p >= argc) return GL_TRUE;
+      params->pixelformat = strtol(argv[p++], NULL, 0);
+    }
+#else
+    else if (!strcmp(argv[p], "-display"))
+    {
+      if (++p >= argc) return GL_TRUE;
+      params->display = argv[p++];
     }
     else if (!strcmp(argv[p], "-visual"))
     {
       if (++p >= argc) return GL_TRUE;
-      *visual = (int)strtol(argv[p++], NULL, 0);
+      params->visual = (int)strtol(argv[p++], NULL, 0);
     }
+#endif
     else
       return GL_TRUE;
-#endif
   }
   return GL_FALSE;
 }
@@ -136,7 +157,7 @@ HWND wnd = NULL;
 HDC dc = NULL;
 HGLRC rc = NULL;
 
-GLboolean glewCreateContext (int* pixelformat)
+GLboolean glewCreateContext (struct createParams* params)
 {
   WNDCLASS wc;
   PIXELFORMATDESCRIPTOR pfd;
@@ -155,20 +176,58 @@ GLboolean glewCreateContext (int* pixelformat)
   if (NULL == dc) return GL_TRUE;
   /* find pixel format */
   ZeroMemory(&pfd, sizeof(PIXELFORMATDESCRIPTOR));
-  if (*pixelformat == -1) /* find default */
+  if (params->pixelformat == -1) /* find default */
   {
     pfd.nSize = sizeof(PIXELFORMATDESCRIPTOR);
     pfd.nVersion = 1;
     pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL;
-    *pixelformat = ChoosePixelFormat(dc, &pfd);
-    if (*pixelformat == 0) return GL_TRUE;
+    params->pixelformat = ChoosePixelFormat(dc, &pfd);
+    if (params->pixelformat == 0) return GL_TRUE;
   }
   /* set the pixel format for the dc */
-  if (FALSE == SetPixelFormat(dc, *pixelformat, &pfd)) return GL_TRUE;
+  if (FALSE == SetPixelFormat(dc, params->pixelformat, &pfd)) return GL_TRUE;
   /* create rendering context */
   rc = wglCreateContext(dc);
   if (NULL == rc) return GL_TRUE;
   if (FALSE == wglMakeCurrent(dc, rc)) return GL_TRUE;
+  if (params->major || params->profile_mask || params->flags)
+  {
+    HGLRC oldRC = rc;
+    int contextAttrs[20];
+    int i;
+
+    extern GLenum GLEWAPIENTRY wglewContextInit();
+    wglewContextInit();
+
+    if (!wglewGetExtension("WGL_ARB_create_context_profile"))
+      return GL_TRUE;
+
+    i = 0;
+    if( params->major )
+    {
+      contextAttrs[i++] = WGL_CONTEXT_MAJOR_VERSION_ARB;
+      contextAttrs[i++] = params->major;
+      contextAttrs[i++] = WGL_CONTEXT_MINOR_VERSION_ARB;
+      contextAttrs[i++] = params->minor;
+    }
+    if( params->profile_mask )
+    {
+      contextAttrs[i++] = WGL_CONTEXT_PROFILE_MASK_ARB;
+      contextAttrs[i++] = params->profile_mask;
+    }
+    if( params->flags )
+    {
+      contextAttrs[i++] = WGL_CONTEXT_FLAGS_ARB;
+      contextAttrs[i++] = params->flags;
+    }
+    contextAttrs[i++] = 0;
+    rc = wglCreateContextAttribsARB(dc, 0, contextAttrs);
+
+    if (NULL == rc) return GL_TRUE;
+    if (!wglMakeCurrent(dc, rc)) return GL_TRUE;
+
+    wglDeleteContext(oldRC);
+  }
   return GL_FALSE;
 }
 
@@ -190,20 +249,23 @@ void glewDestroyContext ()
 
 CGLContextObj ctx, octx;
 
-GLboolean glewCreateContext ()
+GLboolean glewCreateContext (struct createParams *params)
 {
   const CGLPixelFormatAttribute attrib[4] =
   {
     kCGLPFAAccelerated,                                  /* No software rendering */
-#if 0
     kCGLPFAOpenGLProfile,                                /* OSX 10.7 Lion onwards */
     (CGLPixelFormatAttribute) kCGLOGLPVersion_3_2_Core,  /* 3.2 Core Context      */
-#endif
     0
   };
   CGLPixelFormatObj pf;
   GLint npix;
   CGLError error;
+
+  if( params->major < 3 &&
+      !(params->profile_mask & GL_CONTEXT_CORE_PROFILE_BIT) ) {
+    attrib[1] = 0; // terminate attrib array before the core profile attribute
+  }
 
   error = CGLChoosePixelFormat(attrib, &pf, &npix);
   if (error) return GL_TRUE;
@@ -230,7 +292,7 @@ void glewDestroyContext ()
 
 #elif defined(__HAIKU__)
 
-GLboolean glewCreateContext ()
+GLboolean glewCreateContext (struct createParams *params)
 {
   /* TODO: Haiku: We need to call C++ code here */
   return GL_FALSE;
@@ -252,22 +314,22 @@ GLXContext ctx = NULL;
 Window wnd = 0;
 Colormap cmap = 0;
 
-GLboolean glewCreateContext (const char* display, int* visual)
+GLboolean glewCreateContext (struct createParams *params)
 {
   int attrib[] = { GLX_RGBA, GLX_DOUBLEBUFFER, None };
   int erb, evb;
   XSetWindowAttributes swa;
   /* open display */
-  dpy = XOpenDisplay(display);
+  dpy = XOpenDisplay(params->display);
   if (NULL == dpy) return GL_TRUE;
   /* query for glx */
   if (!glXQueryExtension(dpy, &erb, &evb)) return GL_TRUE;
   /* choose visual */
-  if (*visual == -1)
+  if (params->visual == -1)
   {
     vi = glXChooseVisual(dpy, DefaultScreen(dpy), attrib);
     if (NULL == vi) return GL_TRUE;
-    *visual = (int)XVisualIDFromVisual(vi->visual);
+    params->visual = (int)XVisualIDFromVisual(vi->visual);
   }
   else
   {
@@ -275,7 +337,7 @@ GLboolean glewCreateContext (const char* display, int* visual)
     vis = XGetVisualInfo(dpy, 0, NULL, &n_vis);
     for (i=0; i<n_vis; i++)
     {
-      if ((int)XVisualIDFromVisual(vis[i].visual) == *visual)
+      if ((int)XVisualIDFromVisual(vis[i].visual) == params->visual)
         vi = &vis[i];
     }
     if (vi == NULL) return GL_TRUE;
@@ -293,6 +355,54 @@ GLboolean glewCreateContext (const char* display, int* visual)
                       CWBorderPixel | CWColormap, &swa);
   /* make context current */
   if (!glXMakeCurrent(dpy, wnd, ctx)) return GL_TRUE;
+  if (params->major || params->profile_mask || params->flags)
+  {
+    GLXContext oldCtx = ctx;
+    GLXFBConfig *FBConfigs;
+    int FBConfigAttrs[] = { GLX_FBCONFIG_ID, 0, None };
+    int contextAttrs[20];
+    int nelems, i;
+
+    glxewContextInit();
+
+    if (!glxewGetExtension("GLX_ARB_create_context_profile"))
+      return GL_TRUE;
+
+    if (glXQueryContext(dpy, oldCtx, GLX_FBCONFIG_ID, &FBConfigAttrs[1]))
+      return GL_TRUE;
+    FBConfigs = glXChooseFBConfig(dpy, vi->screen, FBConfigAttrs, &nelems);
+
+    if (nelems < 1)
+      return GL_TRUE;
+
+    i = 0;
+    if( params->major )
+    {
+      contextAttrs[i++] = GLX_CONTEXT_MAJOR_VERSION_ARB;
+      contextAttrs[i++] = params->major;
+      contextAttrs[i++] = GLX_CONTEXT_MINOR_VERSION_ARB;
+      contextAttrs[i++] = params->minor;
+    }
+    if( params->profile_mask )
+    {
+      contextAttrs[i++] = GLX_CONTEXT_PROFILE_MASK_ARB;
+      contextAttrs[i++] = params->profile_mask;
+    }
+    if( params->flags )
+    {
+      contextAttrs[i++] = GLX_CONTEXT_FLAGS_ARB;
+      contextAttrs[i++] = params->flags;
+    }
+    contextAttrs[i++] = None;
+    ctx = glXCreateContextAttribsARB(dpy, *FBConfigs, NULL, True, contextAttrs);
+
+    if (NULL == ctx) return GL_TRUE;
+    if (!glXMakeCurrent(dpy, wnd, ctx)) return GL_TRUE;
+
+    glXDestroyContext(dpy, oldCtx);
+
+    XFree(FBConfigs);
+  }
   return GL_FALSE;
 }
 

--- a/config/Makefile.darwin
+++ b/config/Makefile.darwin
@@ -2,6 +2,7 @@ NAME = $(GLEW_NAME)
 CC = cc
 LD = cc
 CFLAGS.EXTRA = -dynamic -fno-common
+CFLAGS.EXTRA += -ansi -pedantic
 #CFLAGS.EXTRA += -no-cpp-precomp
 LDFLAGS.EXTRA =
 ifneq (undefined, $(origin GLEW_APPLE_GLX))

--- a/config/Makefile.linux
+++ b/config/Makefile.linux
@@ -24,6 +24,7 @@ WARN = -Wall -W
 POPT = -O2
 CFLAGS.EXTRA += -fPIC
 CFLAGS.EXTRA += -Wcast-qual
+CFLAGS.EXTRA += -ansi -pedantic
 BIN.SUFFIX =
 LIB.SONAME = lib$(NAME).so.$(SO_MAJOR)
 LIB.DEVLNK = lib$(NAME).so


### PR DESCRIPTION
(Based on part of a pull request by https://github.com/gimhael Pull Request https://github.com/nigels-com/glew/pull/29)

Extend the command-line handling of glewinfo to support GL context version and core/compatible profile.
Tested on Mac OS X by myself.
Reported to also work on Linux GLX. (I'll go second-check)
Needs to be tested on Windows. (I don't have this, currently)