### PR TITLE
glewinfo command-line support for GL context version, profile and flags

### DIFF
--- a/auto/src/glewinfo_head.c
+++ b/auto/src/glewinfo_head.c
@@ -30,16 +30,21 @@ GLXEWContext _glxewctx;
 #endif
 #endif
 
-struct createParams {
+/* Command-line parameters for GL context creation */
+
+struct createParams
+{
 #if defined(_WIN32)
   int         pixelformat;
 #elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
   const char* display;
   int         visual;
 #endif
-  int         major, minor;
-  int         profile_mask;
-  int         flags;
+  int         major, minor;  /* GL context version number */
+
+  /* https://www.opengl.org/registry/specs/ARB/glx_create_context.txt */
+  int         profile_mask;  /* core = 1, compatibility = 2 */
+  int         flags;         /* debug = 1, forward compatible = 2 */
 };
 
 GLboolean glewCreateContext (struct createParams *params);

--- a/auto/src/glewinfo_head.c
+++ b/auto/src/glewinfo_head.c
@@ -43,7 +43,7 @@ struct createParams
   int         major, minor;  /* GL context version number */
 
   /* https://www.opengl.org/registry/specs/ARB/glx_create_context.txt */
-  int         profile_mask;  /* core = 1, compatibility = 2 */
+  int         profile;       /* core = 1, compatibility = 2 */
   int         flags;         /* debug = 1, forward compatible = 2 */
 };
 

--- a/auto/src/glewinfo_head.c
+++ b/auto/src/glewinfo_head.c
@@ -8,6 +8,10 @@
 #include <GL/glxew.h>
 #endif
 
+#if defined(__APPLE__)
+#include <AvailabilityMacros.h>
+#endif
+
 #ifdef GLEW_REGAL
 #include <GL/Regal.h>
 #endif
@@ -40,9 +44,7 @@ struct createParams {
 
 GLboolean glewCreateContext (struct createParams *params);
 
-#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
 GLboolean glewParseArgs (int argc, char** argv, struct createParams *);
-#endif
 
 void glewDestroyContext ();
 

--- a/auto/src/glewinfo_head.c
+++ b/auto/src/glewinfo_head.c
@@ -26,16 +26,22 @@ GLXEWContext _glxewctx;
 #endif
 #endif
 
+struct createParams {
 #if defined(_WIN32)
-GLboolean glewCreateContext (int* pixelformat);
+  int         pixelformat;
 #elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
-GLboolean glewCreateContext (const char* display, int* visual);
-#else
-GLboolean glewCreateContext ();
+  const char* display;
+  int         visual;
 #endif
+  int         major, minor;
+  int         profile_mask;
+  int         flags;
+};
+
+GLboolean glewCreateContext (struct createParams *params);
 
 #if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
-GLboolean glewParseArgs (int argc, char** argv, char** display, int* visual);
+GLboolean glewParseArgs (int argc, char** argv, struct createParams *);
 #endif
 
 void glewDestroyContext ();

--- a/auto/src/glewinfo_tail.c
+++ b/auto/src/glewinfo_tail.c
@@ -7,7 +7,8 @@
 int main (int argc, char** argv)
 {
   GLuint err;
-  struct createParams params = {
+  struct createParams params = 
+  {
 #if defined(_WIN32)
     -1,  /* pixelformat */
 #elif !defined(__HAIKU__) && !defined(__APPLE__) || defined(GLEW_APPLE_GLX)

--- a/auto/src/glewinfo_tail.c
+++ b/auto/src/glewinfo_tail.c
@@ -11,29 +11,38 @@ int main (void)
 #endif
 {
   GLuint err;
+  struct createParams params = {
+#if defined(_WIN32)
+    -1,  /* pixelformat */
+#elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
+    "",  /* display */
+    -1,  /* visual */
+#endif
+    0,   /* major */
+    0,   /* minor */
+    0,   /* profile mask */
+    0    /* flags */
+  };
 
 #if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
-  char* display = NULL;
-  int visual = -1;
-
-  if (glewParseArgs(argc-1, argv+1, &display, &visual))
+  if (glewParseArgs(argc-1, argv+1, &params))
   {
+    fprintf(stderr, "Usage: glewinfo "
 #if defined(_WIN32)
-    fprintf(stderr, "Usage: glewinfo [-pf <id>]\n");
+	    "[-pf <pixelformat>] "
 #else
-    fprintf(stderr, "Usage: glewinfo [-display <display>] [-visual <id>]\n");
+	    "[-display <display>] "
+	    "[-visual <visual id>] "
 #endif
+	    "[-version <OpenGL version>] "
+	    "[-profiles <OpenGL profile mask>] "
+	    "[-flags <OpenGL flags>]"
+	    "\n");
     return 1;
   }
 #endif
 
-#if defined(_WIN32)
-  if (GL_TRUE == glewCreateContext(&visual))
-#elif defined(__APPLE__) && !defined(GLEW_APPLE_GLX)
-  if (GL_TRUE == glewCreateContext())
-#else
-  if (GL_TRUE == glewCreateContext(display, &visual))
-#endif
+  if (GL_TRUE == glewCreateContext(&params))
   {
     fprintf(stderr, "Error: glewCreateContext failed\n");
     glewDestroyContext();
@@ -73,10 +82,10 @@ int main (void)
   fprintf(f, "---------------------------\n\n");
   fprintf(f, "GLEW version %s\n", glewGetString(GLEW_VERSION));
 #if defined(_WIN32)
-  fprintf(f, "Reporting capabilities of pixelformat %d\n", visual);
+  fprintf(f, "Reporting capabilities of pixelformat %d\n", params.pixelformat);
 #elif !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
   fprintf(f, "Reporting capabilities of display %s, visual 0x%x\n", 
-    display == NULL ? getenv("DISPLAY") : display, visual);
+    params.display == NULL ? getenv("DISPLAY") : params.display, params.visual);
 #endif
   fprintf(f, "Running on a %s from %s\n", 
 	  glGetString(GL_RENDERER), glGetString(GL_VENDOR));
@@ -95,34 +104,46 @@ int main (void)
 /* ------------------------------------------------------------------------ */
 
 #if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
-GLboolean glewParseArgs (int argc, char** argv, char** display, int* visual)
+GLboolean glewParseArgs (int argc, char** argv, struct createParams *params)
 {
   int p = 0;
   while (p < argc)
   {
-#if defined(_WIN32)
-    if (!strcmp(argv[p], "-pf") || !strcmp(argv[p], "-pixelformat"))
+    if (!strcmp(argv[p], "-version"))
     {
       if (++p >= argc) return GL_TRUE;
-      *display = 0;
-      *visual = strtol(argv[p++], NULL, 0);
+      if (sscanf(argv[p++], "%d.%d", &params->major, &params->minor) != 2) return GL_TRUE;
     }
-    else
-      return GL_TRUE;
-#else
-    if (!strcmp(argv[p], "-display"))
+    else if (!strcmp(argv[p], "-profiles"))
     {
       if (++p >= argc) return GL_TRUE;
-      *display = argv[p++];
+      params->profile_mask = (int)strtol(argv[p++], NULL, 0);
+    }
+    else if (!strcmp(argv[p], "-flags"))
+    {
+      if (++p >= argc) return GL_TRUE;
+      params->flags = (int)strtol(argv[p++], NULL, 0);
+    }
+#if defined(_WIN32)
+    else if (!strcmp(argv[p], "-pf") || !strcmp(argv[p], "-pixelformat"))
+    {
+      if (++p >= argc) return GL_TRUE;
+      params->pixelformat = strtol(argv[p++], NULL, 0);
+    }
+#else
+    else if (!strcmp(argv[p], "-display"))
+    {
+      if (++p >= argc) return GL_TRUE;
+      params->display = argv[p++];
     }
     else if (!strcmp(argv[p], "-visual"))
     {
       if (++p >= argc) return GL_TRUE;
-      *visual = (int)strtol(argv[p++], NULL, 0);
+      params->visual = (int)strtol(argv[p++], NULL, 0);
     }
+#endif
     else
       return GL_TRUE;
-#endif
   }
   return GL_FALSE;
 }
@@ -136,7 +157,7 @@ HWND wnd = NULL;
 HDC dc = NULL;
 HGLRC rc = NULL;
 
-GLboolean glewCreateContext (int* pixelformat)
+GLboolean glewCreateContext (struct createParams* params)
 {
   WNDCLASS wc;
   PIXELFORMATDESCRIPTOR pfd;
@@ -155,20 +176,58 @@ GLboolean glewCreateContext (int* pixelformat)
   if (NULL == dc) return GL_TRUE;
   /* find pixel format */
   ZeroMemory(&pfd, sizeof(PIXELFORMATDESCRIPTOR));
-  if (*pixelformat == -1) /* find default */
+  if (params->pixelformat == -1) /* find default */
   {
     pfd.nSize = sizeof(PIXELFORMATDESCRIPTOR);
     pfd.nVersion = 1;
     pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL;
-    *pixelformat = ChoosePixelFormat(dc, &pfd);
-    if (*pixelformat == 0) return GL_TRUE;
+    params->pixelformat = ChoosePixelFormat(dc, &pfd);
+    if (params->pixelformat == 0) return GL_TRUE;
   }
   /* set the pixel format for the dc */
-  if (FALSE == SetPixelFormat(dc, *pixelformat, &pfd)) return GL_TRUE;
+  if (FALSE == SetPixelFormat(dc, params->pixelformat, &pfd)) return GL_TRUE;
   /* create rendering context */
   rc = wglCreateContext(dc);
   if (NULL == rc) return GL_TRUE;
   if (FALSE == wglMakeCurrent(dc, rc)) return GL_TRUE;
+  if (params->major || params->profile_mask || params->flags)
+  {
+    HGLRC oldRC = rc;
+    int contextAttrs[20];
+    int i;
+
+    extern GLenum GLEWAPIENTRY wglewContextInit();
+    wglewContextInit();
+
+    if (!wglewGetExtension("WGL_ARB_create_context_profile"))
+      return GL_TRUE;
+
+    i = 0;
+    if( params->major )
+    {
+      contextAttrs[i++] = WGL_CONTEXT_MAJOR_VERSION_ARB;
+      contextAttrs[i++] = params->major;
+      contextAttrs[i++] = WGL_CONTEXT_MINOR_VERSION_ARB;
+      contextAttrs[i++] = params->minor;
+    }
+    if( params->profile_mask )
+    {
+      contextAttrs[i++] = WGL_CONTEXT_PROFILE_MASK_ARB;
+      contextAttrs[i++] = params->profile_mask;
+    }
+    if( params->flags )
+    {
+      contextAttrs[i++] = WGL_CONTEXT_FLAGS_ARB;
+      contextAttrs[i++] = params->flags;
+    }
+    contextAttrs[i++] = 0;
+    rc = wglCreateContextAttribsARB(dc, 0, contextAttrs);
+
+    if (NULL == rc) return GL_TRUE;
+    if (!wglMakeCurrent(dc, rc)) return GL_TRUE;
+
+    wglDeleteContext(oldRC);
+  }
   return GL_FALSE;
 }
 
@@ -190,20 +249,23 @@ void glewDestroyContext ()
 
 CGLContextObj ctx, octx;
 
-GLboolean glewCreateContext ()
+GLboolean glewCreateContext (struct createParams *params)
 {
   const CGLPixelFormatAttribute attrib[4] =
   {
     kCGLPFAAccelerated,                                  /* No software rendering */
-#if 0
     kCGLPFAOpenGLProfile,                                /* OSX 10.7 Lion onwards */
     (CGLPixelFormatAttribute) kCGLOGLPVersion_3_2_Core,  /* 3.2 Core Context      */
-#endif
     0
   };
   CGLPixelFormatObj pf;
   GLint npix;
   CGLError error;
+
+  if( params->major < 3 &&
+      !(params->profile_mask & GL_CONTEXT_CORE_PROFILE_BIT) ) {
+    attrib[1] = 0; // terminate attrib array before the core profile attribute
+  }
 
   error = CGLChoosePixelFormat(attrib, &pf, &npix);
   if (error) return GL_TRUE;
@@ -230,7 +292,7 @@ void glewDestroyContext ()
 
 #elif defined(__HAIKU__)
 
-GLboolean glewCreateContext ()
+GLboolean glewCreateContext (struct createParams *params)
 {
   /* TODO: Haiku: We need to call C++ code here */
   return GL_FALSE;
@@ -252,22 +314,22 @@ GLXContext ctx = NULL;
 Window wnd = 0;
 Colormap cmap = 0;
 
-GLboolean glewCreateContext (const char* display, int* visual)
+GLboolean glewCreateContext (struct createParams *params)
 {
   int attrib[] = { GLX_RGBA, GLX_DOUBLEBUFFER, None };
   int erb, evb;
   XSetWindowAttributes swa;
   /* open display */
-  dpy = XOpenDisplay(display);
+  dpy = XOpenDisplay(params->display);
   if (NULL == dpy) return GL_TRUE;
   /* query for glx */
   if (!glXQueryExtension(dpy, &erb, &evb)) return GL_TRUE;
   /* choose visual */
-  if (*visual == -1)
+  if (params->visual == -1)
   {
     vi = glXChooseVisual(dpy, DefaultScreen(dpy), attrib);
     if (NULL == vi) return GL_TRUE;
-    *visual = (int)XVisualIDFromVisual(vi->visual);
+    params->visual = (int)XVisualIDFromVisual(vi->visual);
   }
   else
   {
@@ -275,7 +337,7 @@ GLboolean glewCreateContext (const char* display, int* visual)
     vis = XGetVisualInfo(dpy, 0, NULL, &n_vis);
     for (i=0; i<n_vis; i++)
     {
-      if ((int)XVisualIDFromVisual(vis[i].visual) == *visual)
+      if ((int)XVisualIDFromVisual(vis[i].visual) == params->visual)
         vi = &vis[i];
     }
     if (vi == NULL) return GL_TRUE;
@@ -293,6 +355,54 @@ GLboolean glewCreateContext (const char* display, int* visual)
                       CWBorderPixel | CWColormap, &swa);
   /* make context current */
   if (!glXMakeCurrent(dpy, wnd, ctx)) return GL_TRUE;
+  if (params->major || params->profile_mask || params->flags)
+  {
+    GLXContext oldCtx = ctx;
+    GLXFBConfig *FBConfigs;
+    int FBConfigAttrs[] = { GLX_FBCONFIG_ID, 0, None };
+    int contextAttrs[20];
+    int nelems, i;
+
+    glxewContextInit();
+
+    if (!glxewGetExtension("GLX_ARB_create_context_profile"))
+      return GL_TRUE;
+
+    if (glXQueryContext(dpy, oldCtx, GLX_FBCONFIG_ID, &FBConfigAttrs[1]))
+      return GL_TRUE;
+    FBConfigs = glXChooseFBConfig(dpy, vi->screen, FBConfigAttrs, &nelems);
+
+    if (nelems < 1)
+      return GL_TRUE;
+
+    i = 0;
+    if( params->major )
+    {
+      contextAttrs[i++] = GLX_CONTEXT_MAJOR_VERSION_ARB;
+      contextAttrs[i++] = params->major;
+      contextAttrs[i++] = GLX_CONTEXT_MINOR_VERSION_ARB;
+      contextAttrs[i++] = params->minor;
+    }
+    if( params->profile_mask )
+    {
+      contextAttrs[i++] = GLX_CONTEXT_PROFILE_MASK_ARB;
+      contextAttrs[i++] = params->profile_mask;
+    }
+    if( params->flags )
+    {
+      contextAttrs[i++] = GLX_CONTEXT_FLAGS_ARB;
+      contextAttrs[i++] = params->flags;
+    }
+    contextAttrs[i++] = None;
+    ctx = glXCreateContextAttribsARB(dpy, *FBConfigs, NULL, True, contextAttrs);
+
+    if (NULL == ctx) return GL_TRUE;
+    if (!glXMakeCurrent(dpy, wnd, ctx)) return GL_TRUE;
+
+    glXDestroyContext(dpy, oldCtx);
+
+    XFree(FBConfigs);
+  }
   return GL_FALSE;
 }
 


### PR DESCRIPTION
(Based on part of a pull request by https://github.com/gimhael Pull Request https://github.com/nigels-com/glew/pull/29)

Extend the command-line handling of glewinfo to support GL context version and core/compatible profile.
Tested on Mac OS X by myself.
Reported to also work on Linux GLX. (I'll go second-check)
Needs to be tested on Windows. (I don't have this, currently)