### PR TITLE
build: cmake-testbuild to work on OS X and with CMake < 3.0

### DIFF
--- a/build/cmake/testbuild/CMakeLists.txt
+++ b/build/cmake/testbuild/CMakeLists.txt
@@ -10,9 +10,9 @@ target_link_libraries(cmake-test PRIVATE GLEW::GLEW ${OPENGL_LIBRARIES})
 target_include_directories(cmake-test PRIVATE ${OPENGL_INCLUDE_DIR})
 
 if(CMAKE_VERSION VERSION_LESS 3.0)
-    set(cgex $<CONFIG>)
-else()
     set(cgex $<CONFIGURATION>)
+else()
+    set(cgex $<CONFIG>)
 endif()
 
 target_compile_definitions(cmake-test PRIVATE

--- a/cmake-testbuild.sh
+++ b/cmake-testbuild.sh
@@ -65,6 +65,7 @@ cmake out/build/cmake-testbuild -DCMAKE_BUILD_TYPE=Release
 cmake --build out/build/cmake-testbuild --target install --config Release --clean-first
 
 export LD_LIBRARY_PATH=${PWD}/out/lib:$LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH=${PWD}/out/lib:$DYLD_LIBRARY_PATH
 
 out/bin/cmake-test_d
 out/bin/cmake-test


### PR DESCRIPTION
fixes a typo (swapped if-else branches) and sets DYLD_LIBRARY_PATH for OSX