### PR TITLE
cmake: allow calling find_package(GLEW CONFIG) multiple times

### DIFF
--- a/build/cmake/glew-config.cmake
+++ b/build/cmake/glew-config.cmake
@@ -40,7 +40,21 @@ endif()
 foreach(_glew_target glew glewmx)
   set(_glew_src_target "GLEW::${_glew_target}${_glew_target_postfix}")
   string(TOUPPER "GLEW::${_glew_target}" _glew_dest_target)
-  add_library(${_glew_dest_target} ${_glew_target_type} IMPORTED)
-  # message(STATUS "add_library(${_glew_dest_target} ${_glew_target_type} IMPORTED)")
-  copy_imported_target_properties(${_glew_src_target} ${_glew_dest_target})
+  if(TARGET ${_glew_dest_target})
+    get_target_property(_glew_previous_src_target ${_glew_dest_target}
+      _GLEW_SRC_TARGET)
+    if(NOT _glew_previous_src_target STREQUAL _glew_src_target)
+      message(FATAL_ERROR "find_package(GLEW) was called the second time with "
+        "different GLEW_USE_STATIC_LIBS setting. Previously, "
+        "`glew-config.cmake` created ${_glew_dest_target} as a copy of "
+        "${_glew_previous_src_target}. Now it attempted to copy it from "
+        "${_glew_src_target}. ")
+    endif()
+  else()
+    add_library(${_glew_dest_target} ${_glew_target_type} IMPORTED)
+    # message(STATUS "add_library(${_glew_dest_target} ${_glew_target_type} IMPORTED)")
+    copy_imported_target_properties(${_glew_src_target} ${_glew_dest_target})
+    set_target_properties(${_glew_dest_target} PROPERTIES
+      _GLEW_SRC_TARGET ${_glew_src_target})
+  endif()
 endforeach()

--- a/build/cmake/testbuild/CMakeLists.txt
+++ b/build/cmake/testbuild/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(glew-cmake-test)
 
 find_package(GLEW REQUIRED CONFIG)
+find_package(GLEW REQUIRED CONFIG) # call twice to test multiple call
 find_package(OpenGL REQUIRED)
 
 add_executable(cmake-test main.c)


### PR DESCRIPTION
Previously, the config-module failed when it was called multiple times.

This fix allows calling `find_package(GLEW CONFIG)` multiple times.
Also, it gives a descriptive error message when called multiple times
with contradicting `GLEW_USE_STATIC_LIBS` settings.

`cmake-testbuild.sh` (`build/cmake/testbuild/CMakeLists.txt`) calls
`find_package(GLEW)` twice to test this fix.