### PR TITLE
Replace int with ptrdiff_t to store the result of pointer subtraction

### DIFF
--- a/auto/src/glew_init_gl.c
+++ b/auto/src/glew_init_gl.c
@@ -8,7 +8,7 @@ static int _glewExtensionCompare(const void *a, const void *b)
 static GLboolean *_glewGetExtensionString(const char *name)
 {
   const char **n = (const char **) bsearch(name, _glewExtensionLookup, sizeof(_glewExtensionLookup)/sizeof(char *)-1, sizeof(char *), _glewExtensionCompare);
-  int i;
+  ptrdiff_t i;
 
   if (n)
   {
@@ -22,7 +22,7 @@ static GLboolean *_glewGetExtensionString(const char *name)
 static GLboolean *_glewGetExtensionEnable(const char *name)
 {
   const char **n = (const char **) bsearch(name, _glewExtensionLookup, sizeof(_glewExtensionLookup)/sizeof(char *)-1, sizeof(char *), _glewExtensionCompare);
-  int i;
+  ptrdiff_t i;
 
   if (n)
   {


### PR DESCRIPTION
Pointer subtraction doesn't always return an int, so this should at least prevent some compiler warnings when compiling for x64.