### PR TITLE
Install MSVC program database when building `Debug` or `RelWithDebInfo` configuration

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -191,6 +191,14 @@ install(FILES ${GLEW_DIR}/glew.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
+if((NOT MSVC_VERSION LESS 1600) AND (NOT CMAKE_VERSION VERSION_LESS "3.1"))
+    install(
+        FILES $<TARGET_PDB_FILE:glew>
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        CONFIGURATIONS Debug RelWithDebInfo
+    )
+endif()
+
 install (FILES
     ${GLEW_DIR}/include/GL/wglew.h
     ${GLEW_DIR}/include/GL/glew.h


### PR DESCRIPTION
This PR add an additional install step, which installs the [Program Database File]  when using a reasonable recent Microsoft compiler with the CMake `Debug` or `RelWithDebInfo` configuration.  The additional 'is this at least the VS 2010 compiler' and 'is this at least CMake 3.1' conditions exist because a) pdb files are generated by default only on VS 2010 or later and therefor don't introduce unexpected behaviour and b) only CMake 3.1 and later introduce the TARGET_PDB_FILE generator expression to reliable locate the the .pdb file.

I chose the libdir as target installation location because the pdb is a important development file but should not distributed necessarily to users.

[Program Database File]: https://msdn.microsoft.com/en-us/library/yd4f8bd1(v=vs.100).aspx