### PR TITLE
Fix wglGetProcAddress-related crash on 64-bit Windows with NOGDI defined

### DIFF
--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -6,6 +6,14 @@
 #elif defined(GLEW_EGL)
 #  include <GL/eglew.h>
 #elif defined(_WIN32)
+/*
+ * If NOGDI is defined, wingdi.h won't be included by windows.h, and thus
+ * wglGetProcAddress won't be declared. It will instead be implicitly declared,
+ * potentially incorrectly, which we don't want.
+ */
+#  if defined(NOGDI)
+#    undef NOGDI
+#  endif
 #  include <GL/wglew.h>
 #elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && (!defined(__APPLE__) || defined(GLEW_APPLE_GLX))
 #  include <GL/glxew.h>

--- a/auto/src/wglew_head.h
+++ b/auto/src/wglew_head.h
@@ -12,6 +12,14 @@
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN 1
 #  endif
+/*
+ * If NOGDI is defined, wingdi.h won't be included by windows.h, and thus
+ * wglGetProcAddress won't be declared. It will instead be implicitly declared
+ * incorrectly, which we don't want.
+ */
+#  if defined(NOGDI)
+#    undef NOGDI
+#  endif
 #include <windows.h>
 #  undef WIN32_LEAN_AND_MEAN
 #endif

--- a/auto/src/wglew_head.h
+++ b/auto/src/wglew_head.h
@@ -12,14 +12,6 @@
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN 1
 #  endif
-/*
- * If NOGDI is defined, wingdi.h won't be included by windows.h, and thus
- * wglGetProcAddress won't be declared. It will instead be implicitly declared
- * incorrectly, which we don't want.
- */
-#  if defined(NOGDI)
-#    undef NOGDI
-#  endif
 #include <windows.h>
 #  undef WIN32_LEAN_AND_MEAN
 #endif


### PR DESCRIPTION
The issue I was running into:

I was building glew with my 64-bit project on Windows, and I had `NOGDI` defined for my entire project (to avoid some conflicts). Because `NOGDI` was defined, wingdi.h was not included by windows.h in glew.c. This caused glew.c to implicitly declare `wglGetProcAddress` as a function returning an `int` (32-bit), when it should be a function returning a 64-bit type. Voila, crash!

This fix forces windows.h to include wingdi.h when `NOGDI` has been defined on the command line. Another fix would be to manually include wingdi.h or delclare `wglGetProcAddress` directly in glew's Windows header.