### PR TITLE
Sub-targets of glew.lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,10 @@ LIB.OBJS           := $(LIB.OBJS:.c=.o)
 LIB.SOBJS          := $(addprefix tmp/$(SYSTEM)/default/shared/,$(LIB.SRCS.NAMES))
 LIB.SOBJS          := $(LIB.SOBJS:.c=.o)
 
-glew.lib: lib lib/$(LIB.SHARED) lib/$(LIB.STATIC) glew.pc
+glew.lib: glew.lib.shared glew.lib.static
+
+glew.lib.shared: lib lib/$(LIB.SHARED) glew.pc
+glew.lib.static: lib lib/$(LIB.STATIC) glew.pc
 
 lib:
 	mkdir lib

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ RedHat/CentOS/Fedora:  `$ sudo yum install libXmu-devel libXi-devel libGL-devel 
 	$ sudo make install
 	$ make clean
 
-Targets:    `all, glew.lib, glew.bin, clean, install, uninstall`
+Targets:    `all, glew.lib (sub-targets: glew.lib.shared, glew.lib.static), glew.bin, clean, install, uninstall`
 
 Variables:  `SYSTEM=linux-clang, GLEW_DEST=/usr/local, STRIP=`
 


### PR DESCRIPTION
As mentioned in #104, this allows one to simply `make` GLEW in one of the following modes:
- shared + static
- shared
- static