### PR TITLE
Support custom callback to resolve OpenGL entry points

### DIFF
--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -122,7 +122,11 @@ void* NSGLGetProcAddress (const GLubyte *name)
 /*
  * Define glewGetProcAddress.
  */
-#if defined(GLEW_REGAL)
+#if defined(GLEW_CUSTOM_GET_PROC_ADDRESS)
+   glewResolveProcType glewResolveProc;
+   glewResolveDataType glewResolveData;
+#  define glewGetProcAddress(name) glewResolveProc((const char*)name, glewResolveData)
+#elif defined(GLEW_REGAL)
 #  define glewGetProcAddress(name) regalGetProcAddress((const GLchar *)name)
 #elif defined(GLEW_OSMESA)
 #  define glewGetProcAddress(name) OSMesaGetProcAddress((const char *)name)

--- a/auto/src/glew_head.h
+++ b/auto/src/glew_head.h
@@ -187,6 +187,23 @@ typedef _W64 int ptrdiff_t;
 #define GLEW_VAR_EXPORT GLEWAPI
 #define GLEW_FUN_EXPORT GLEWAPI
 
+/*
+ * If you're integrating glew with something like Qt you really want to use
+ * the context created by Qt to resolve the function pointers.
+ * In this case define GLEW_CUSTOM_GET_PROC_ADDRESS and set the pointer below
+ * to your callback function.
+*/
+
+#ifdef GLEW_CUSTOM_GET_PROC_ADDRESS
+ typedef void*  glewResolveDataType;
+ typedef void* (*glewResolveProcType)(const char*, glewResolveDataType user);
+
+ /* This is your callback */
+ extern glewResolveProcType glewResolveProc;
+ /* This is your (optional) callback data */
+ extern glewResolveDataType glewResolveData;
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
There's a need to be able to define a custom callback to resolve
the OpenGL entry points. For example when integrating with 3rd party
toolkits such as Qt. Glew doesn't know the underlying implementation
and the entry point resolution really needs to happen through the
context object created by Qt.

Implementation for issue #106
