### PR TITLE
Resolve issue #99: Removed /RTC1 flag in glew…

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -101,6 +101,7 @@ if (MSVC)
   target_compile_options (glew_s PRIVATE -GS-)
   # remove stdlib dependency
   target_link_libraries (glew LINK_PRIVATE -nodefaultlib -noentry)
+  string(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG})
 elseif (WIN32 AND ((CMAKE_C_COMPILER_ID MATCHES "GNU") OR (CMAKE_C_COMPILER_ID MATCHES "Clang")))
   # remove stdlib dependency on windows with GCC and Clang (for similar reasons
   # as to MSVC - to allow it to be used with any Windows compiler)


### PR DESCRIPTION
… project under MSVC, which otherwise causes building to fail on Win64 Debug mode.

Please test on other MSVC platforms; I have only tested this on Windows 8.1, VS2015 (fully patched), Win64 mode.

I may also look through other Windows related bugs and try to add on to this PR.

Reference: Issue #99 