### PR TITLE
add sudo make uninstall for cmake build

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -228,3 +228,14 @@ if(MAYBE_EXPORT)
       ${CMAKE_CURRENT_SOURCE_DIR}/CopyImportedTargetProperties.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/glew)
 endif()
+
+if(NOT TARGET uninstall)
+  configure_file(
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+      IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+      COMMAND ${CMAKE_COMMAND} -P
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()

--- a/build/cmake/cmake_uninstall.cmake.in
+++ b/build/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,26 @@
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+if (NOT DEFINED CMAKE_INSTALL_PREFIX)
+  set (CMAKE_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@")
+endif ()
+ message(${CMAKE_INSTALL_PREFIX})
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)


### PR DESCRIPTION
This features reduces the pain of having to remove the installed libraries and headers in /usr/local/ one by one.

Before this change

``````
jasjuang@jasjuang-ubuntu:~/glew-2.0.0/build$ sudo make install
[sudo] password for hypevr: 
[ 25%] Built target glew
[ 50%] Built target glew_s
[ 75%] Built target visualinfo
[100%] Built target glewinfo
Install the project...
-- Install configuration: "Release"
-- Installing: /usr/local/lib/libGLEW.so
-- Installing: /usr/local/lib/libGLEW.a
-- Installing: /usr/local/bin/glewinfo
-- Set runtime path of "/usr/local/bin/glewinfo" to ""
-- Installing: /usr/local/bin/visualinfo
-- Set runtime path of "/usr/local/bin/visualinfo" to ""
-- Installing: /usr/local/lib/pkgconfig/glew.pc
-- Installing: /usr/local/include/GL/wglew.h
-- Installing: /usr/local/include/GL/glew.h
-- Installing: /usr/local/include/GL/glxew.h
-- Installing: /usr/local/lib/cmake/glew/glew-targets.cmake
-- Installing: /usr/local/lib/cmake/glew/glew-targets-release.cmake
-- Installing: /usr/local/lib/cmake/glew/glew-config.cmake
-- Installing: /usr/local/lib/cmake/glew/CopyImportedTargetProperties.cmake
jasjuang@jasjuang-ubuntu:~/glew-2.0.0/build$ sudo make uninstall
make: *** No rule to make target 'uninstall'.  Stop.
``````

Painful! Need to remove those installed files one by one. With this new feature,

``````
jasjuang@jasjuang-ubuntu:~/glew-2.0.0/build$ sudo make uninstall
Scanning dependencies of target uninstall
/usr/local
-- Uninstalling /usr/local/lib/libGLEW.so
-- Uninstalling /usr/local/lib/libGLEW.a
-- Uninstalling /usr/local/bin/glewinfo
-- Uninstalling /usr/local/bin/visualinfo
-- Uninstalling /usr/local/lib/pkgconfig/glew.pc
-- Uninstalling /usr/local/include/GL/wglew.h
-- Uninstalling /usr/local/include/GL/glew.h
-- Uninstalling /usr/local/include/GL/glxew.h
-- Uninstalling /usr/local/lib/cmake/glew/glew-targets.cmake
-- Uninstalling /usr/local/lib/cmake/glew/glew-targets-release.cmake
-- Uninstalling /usr/local/lib/cmake/glew/glew-config.cmake
-- Uninstalling /usr/local/lib/cmake/glew/CopyImportedTargetProperties.cmake
Built target uninstall
``````

Simple!