### PR TITLE
The install_manifest.txt is actually in the top-level binary director…

### DIFF
--- a/build/cmake/cmake_uninstall.cmake.in
+++ b/build/cmake/cmake_uninstall.cmake.in
@@ -1,13 +1,13 @@
-if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
-  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
-endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
 
 if (NOT DEFINED CMAKE_INSTALL_PREFIX)
   set (CMAKE_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@")
 endif ()
  message(${CMAKE_INSTALL_PREFIX})
 
-file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
 string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
   message(STATUS "Uninstalling $ENV{DESTDIR}${file}")


### PR DESCRIPTION
…y, not the project-specific binary directory.  I get the CMake error 'Cannot find install manifest' if I've added the glew library as a subdirectory in my existing CMake project.