### PR TITLE
Updated build instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ RedHat/CentOS/Fedora:  `$ sudo yum install libXmu-devel libXi-devel libGL-devel`
 
 ##### Build
 
+	$ cd auto
+	$ make
+	$ cd ..
 	$ make
 	$ sudo make install
 	$ make clean
@@ -61,13 +64,15 @@ _Note: may need to make **auto** folder_
 
 ##### Install build tools
 
-Debian/Ubuntu/Mint:   `$ sudo apt-get install build-essential libXmu-dev libXi-dev libgl-dev cmake`
+Debian/Ubuntu/Mint:   `$ sudo apt-get install build-essential libxmu-dev libxi-dev libgl-dev cmake`
 
 RedHat/CentOS/Fedora: `$ sudo yum install libXmu-devel libXi-devel libGL-devel cmake`
 
 ##### Build
 
-	$ cd build
+	$ cd auto
+	$ make
+	$ cd ../build
 	$ cmake ./cmake 
 	$ make -j4
 


### PR DESCRIPTION
I've tried the build steps as described on the README.md on a Linux Ubuntu distro. It comes out that some third-party packages glew depends on have wrong name in the README.md file and that the build instructions are incomplete: both on them (CMake and GNUMakeFile version) fail if it hasn't been runned a make command in SOURCE_ROOT/auto folder before.