### PR TITLE
Fixed compilation with current mesa versions.

### DIFF
--- a/auto/src/glew_head.h
+++ b/auto/src/glew_head.h
@@ -14,7 +14,7 @@
 #if defined(__REGAL_H__)
 #error Regal.h included before glew.h
 #endif
-#if defined(__glext_h_) || defined(__GLEXT_H_)
+#if defined(__glext_h_) || defined(__GLEXT_H_) || defined(__gl_glext_h_)
 #error glext.h included before glew.h
 #endif
 #if defined(__gl_ATI_h_)
@@ -30,6 +30,7 @@
 #define __X_GL_H
 #define __glext_h_
 #define __GLEXT_H_
+#define __gl_glext_h_
 #define __gl_ATI_h_
 
 #if defined(_WIN32)


### PR DESCRIPTION
As you can see in
https://cgit.freedesktop.org/mesa/mesa/tree/include/GL/glext.h
now the file uses __gl_glext_h_ instead of __glext_h_
It's precisely caused by commit f7d42ee7d319256608ad60778f6787c140badada