### PR TITLE
[filter_gl_ext] removed command that currently not applicable.

### DIFF
--- a/auto/bin/filter_gl_ext.sh
+++ b/auto/bin/filter_gl_ext.sh
@@ -77,10 +77,6 @@ EOT
 # fix GL_NV_occlusion_query and GL_HP_occlusion_test
     grep -v '_HP' $1/GL_NV_occlusion_query > tmp
     mv tmp $1/GL_NV_occlusion_query
-    perl -e's/OCCLUSION_TEST_HP.*/OCCLUSION_TEST_HP 0x8165/' -pi \
-	$1/GL_HP_occlusion_test
-    perl -e's/OCCLUSION_TEST_RESULT_HP.*/OCCLUSION_TEST_RESULT_HP 0x8166/' -pi \
-	$1/GL_HP_occlusion_test
 
 # add deprecated constants to GL_ATI_fragment_shader
     cat >> $1/GL_ATI_fragment_shader <<EOT
@@ -337,11 +333,6 @@ EOT
 # Remove glGetPointerv from GL_KHR_debug
     grep -v "glGetPointerv" $1/GL_KHR_debug > tmp
     mv tmp $1/GL_KHR_debug
-
-# Remove GL_ARB_debug_group, GL_ARB_debug_label and GL_ARB_debug_output2, for now
-    rm -f $1/GL_ARB_debug_group
-    rm -f $1/GL_ARB_debug_label
-    rm -f $1/GL_ARB_debug_output2
 
 # add typedefs to GL_ARB_cl_event
 # parse_spec.pl can't parse typedefs from New Types section, but ought to


### PR DESCRIPTION
Hello.

Proposed to remove commands that do nothing because extensions with names from commands not exists any more.

Thank you.

P.S.
Build [glew_generator](https://gist.github.com/TheVice/421cb7df499b7515e6f5e278e4335b87) in debug mode to see more, for example you can view next output:
```
[Warning]: Command 'perl -e 's/handle /GLhandleARB /g' -pi $1/GL_ARB_vertex_shader' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/REGAL/.*#https://github.com/p3/regal/tree/master/doc/extensions#g' -pi GL_REGAL_ES1_0_compatibility' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/REGAL/.*#https://github.com/p3/regal/tree/master/doc/extensions#g' -pi GL_REGAL_ES1_1_compatibility' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/REGAL/.*#https://github.com/p3/regal/tree/master/doc/extensions#g' -pi GL_REGAL_enable' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/REGAL/.*#https://github.com/p3/regal/tree/master/doc/extensions#g' -pi GL_REGAL_error_string' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/REGAL/.*#https://github.com/p3/regal/tree/master/doc/extensions#g' -pi GL_REGAL_extension_query' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/REGAL/.*#https://github.com/p3/regal/tree/master/doc/extensions#g' -pi GL_REGAL_log' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/REGAL/.*#https://github.com/p3/regal/tree/master/doc/extensions#g' -pi GL_REGAL_proc_address' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/ANGLE/.*#https://code.google.com/p/angleproject/source/browse/\#git%2Fextensions#g' -pi GL_ANGLE_framebuffer_blit' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/ANGLE/.*#https://code.google.com/p/angleproject/source/browse/\#git%2Fextensions#g' -pi GL_ANGLE_framebuffer_multisample' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/ANGLE/.*#https://code.google.com/p/angleproject/source/browse/\#git%2Fextensions#g' -pi GL_ANGLE_instanced_arrays' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/ANGLE/.*#https://code.google.com/p/angleproject/source/browse/\#git%2Fextensions#g' -pi GL_ANGLE_pack_reverse_row_order' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/ANGLE/.*#https://code.google.com/p/angleproject/source/browse/\#git%2Fextensions#g' -pi GL_ANGLE_program_binary' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/ANGLE/.*#https://code.google.com/p/angleproject/source/browse/\#git%2Fextensions#g' -pi GL_ANGLE_texture_compression_dxt1' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/ANGLE/.*#https://code.google.com/p/angleproject/source/browse/\#git%2Fextensions#g' -pi GL_ANGLE_texture_compression_dxt3' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/ANGLE/.*#https://code.google.com/p/angleproject/source/browse/\#git%2Fextensions#g' -pi GL_ANGLE_texture_compression_dxt5' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/ANGLE/.*#https://code.google.com/p/angleproject/source/browse/\#git%2Fextensions#g' -pi GL_ANGLE_translated_shader_source' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/ANGLE/.*#https://code.google.com/p/angleproject/source/browse/\#git%2Fextensions#g' -pi GL_ANGLE_timer_query' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/ANGLE/.*#https://code.google.com/p/angleproject/source/browse/\#git%2Fextensions#g' -pi GL_ANGLE_depth_texture' was not be applied.
[Warning]: Command 'perl -e 's#http://www.opengl.org/registry/specs/ANGLE/.*#https://code.google.com/p/angleproject/source/browse/\#git%2Fextensions#g' -pi GL_ANGLE_texture_usage' was not be applied.
```

In addition to previous command, that proposed to remove in this request.

First one need addition checking, however it can also be safe removed. Rest can be fixed by two different approach:
change url's in a script or in original specification (glfixes repository) from that extensions was generated.