### PR TITLE
Extend glewinfo to support optional -experimental mode

### DIFF
--- a/auto/Makefile
+++ b/auto/Makefile
@@ -286,7 +286,7 @@ $(S.DEST)/glewinfo.c: $(EXT)/.dummy
 	$(BIN)/make_info_list.pl $(EGL_CORE_SPEC) >> $@
 	$(BIN)/make_info_list.pl $(EGL_EXT_SPEC) >> $@
 	cat $(SRC)/glewinfo_tail.c >> $@
-	perl -e 's/"glColorSubTable"/"glBlendEquation", glBlendEquation == NULL);\n  glewInfoFunc("glColorSubTable"/g' -pi $@
+	perl -e 's/"glColorSubTable"/"glBlendEquation", glBlendEquation == NULL);\n  glewInfoFunc(fi, "glColorSubTable"/g' -pi $@
 	rm -f $@.bak
 
 # Update documentation

--- a/auto/bin/make_info.pl
+++ b/auto/bin/make_info.pl
@@ -19,7 +19,7 @@ do 'bin/make.pl';
 sub make_pfn_info($%)
 {
     my $name = $_[0];
-    return "  glewInfoFunc(\"$_[0]\", $name == NULL);";
+    return "  glewInfoFunc(fi, \"$_[0]\", $name == NULL);";
 }
 
 #---------------------------------------------------------------------------------------
@@ -43,13 +43,23 @@ if (@ARGV)
 		#make_separator($extname);
 		print "#ifdef $extname\n\n";
 		print "static void _glewInfo_$extname (void)\n{\n";
-		if ($extvar =~ /VERSION/)
+
+		if (! %$functions)
 		{
-			print "  glewPrintExt(\"$extname\", $extvar, $extvar, $extvar);\n";
+			print "  ";		
 		}
 		else
 		{
-			print "  glewPrintExt(\"$extname\", $extvar, $extpre" .
+			print "  GLboolean fi = ";		
+		}
+
+		if ($extvar =~ /VERSION/)
+		{
+			print "glewPrintExt(\"$extname\", $extvar, $extvar, $extvar);\n";
+		}
+		else
+		{
+			print "glewPrintExt(\"$extname\", $extvar, $extpre" .
 				"ewIsSupported(\"$extname\"), $extpre" .
 				"ewGetExtension(\"$extstring\"));\n";
 		}

--- a/auto/src/glewinfo_head.c
+++ b/auto/src/glewinfo_head.c
@@ -40,6 +40,9 @@ struct createParams
   /* https://www.opengl.org/registry/specs/ARB/glx_create_context.txt */
   int         profile;       /* core = 1, compatibility = 2 */
   int         flags;         /* debug = 1, forward compatible = 2 */
+
+  /* GLEW experimental mode */
+  int         experimental;
 };
 
 GLboolean glewCreateContext (struct createParams *params);
@@ -50,7 +53,7 @@ void glewDestroyContext ();
 
 /* ------------------------------------------------------------------------- */
 
-static void glewPrintExt (const char* name, GLboolean def1, GLboolean def2, GLboolean def3)
+static GLboolean glewPrintExt (const char* name, GLboolean def1, GLboolean def2, GLboolean def3)
 {
   unsigned int i;
   fprintf(f, "\n%s:", name);
@@ -65,15 +68,19 @@ static void glewPrintExt (const char* name, GLboolean def1, GLboolean def2, GLbo
   for (i=0; i<strlen(name)+1; i++) fprintf(f, "-");
   fprintf(f, "\n");
   fflush(f);
+  return def1 || def2 || def3 || glewExperimental; /* Enable per-function info too? */
 }
 
-static void glewInfoFunc (const char* name, GLint undefined)
+static void glewInfoFunc (GLboolean fi, const char* name, GLint undefined)
 {
   unsigned int i;
-  fprintf(f, "  %s:", name);
-  for (i=0; i<60-strlen(name); i++) fprintf(f, " ");
-  fprintf(f, "%s\n", undefined ? "MISSING" : "OK");
-  fflush(f);
+  if (fi)
+  {
+    fprintf(f, "  %s:", name);
+    for (i=0; i<60-strlen(name); i++) fprintf(f, " ");
+    fprintf(f, "%s\n", undefined ? "MISSING" : "OK");
+    fflush(f);
+  }
 }
 
 /* ----------------------------- GL_VERSION_1_1 ---------------------------- */

--- a/auto/src/glewinfo_tail.c
+++ b/auto/src/glewinfo_tail.c
@@ -20,7 +20,8 @@ int main (int argc, char** argv)
     0,   /* major */
     0,   /* minor */
     0,   /* profile mask */
-    0    /* flags */
+    0,   /* flags */
+    0    /* experimental */
   };
 
 #if defined(GLEW_EGL)
@@ -41,7 +42,8 @@ int main (int argc, char** argv)
 #endif
       "[-version <OpenGL version>] "
       "[-profile core|compatibility] "
-      "[-flag debug|forward]"
+      "[-flag debug|forward] "
+      "[-experimental]"
       "\n");
     return 1;
   }
@@ -52,7 +54,7 @@ int main (int argc, char** argv)
     glewDestroyContext();
     return 1;
   }
-  glewExperimental = GL_TRUE;
+  glewExperimental = params.experimental ? GL_TRUE : GL_FALSE;
   err = glewInit();
   if (GLEW_OK != err)
   {
@@ -158,13 +160,18 @@ GLboolean glewParseArgs (int argc, char** argv, struct createParams *params)
     {
       if (++p >= argc) return GL_TRUE;
       params->display = argv[p++];
-     }
+    }
     else if (!strcmp(argv[p], "-visual"))
     {
       if (++p >= argc) return GL_TRUE;
       params->visual = (int)strtol(argv[p++], NULL, 0);
     }
 #endif
+    else if (!strcmp(argv[p], "-experimental"))
+    {
+      params->experimental = 1;
+      ++p;
+    }
     else
       return GL_TRUE;
   }


### PR DESCRIPTION
`glewinfo` currently operates in experimental mode by default.

For clarity, and to discourage the use of experimental mode, make it an opt-in with `-experimental`.

Missing extensions are output merely as MISSING, rather than listing each entry point.

In experimental mode, all entry points are listed as previously.