### PR TITLE
Extend glew.pc output to mention GL linking (-framework on OSX)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ glew.pc: glew.pc.in
 		-e "s|@version@|$(GLEW_VERSION)|g" \
 		-e "s|@cflags@||g" \
 		-e "s|@libname@|$(NAME)|g" \
+		-e "s|@libgl@|$(LDFLAGS.GL)|g" \
 		-e "s|@requireslib@|$(LIBGLU)|g" \
 		< $< > $@
 

--- a/glew.pc.in
+++ b/glew.pc.in
@@ -7,5 +7,5 @@ Name: glew
 Description: The OpenGL Extension Wrangler library
 Version: @version@
 Cflags: -I${includedir} @cflags@
-Libs: -L${libdir} -l@libname@
+Libs: -L${libdir} -l@libname@ @libgl@
 Requires: @requireslib@


### PR DESCRIPTION
Resolve issue #202 

```
$ make glew.pc
sed \
		-e "s|@prefix@|/usr|g" \
		-e "s|@libdir@|/usr/local/lib|g" \
		-e "s|@exec_prefix@|/usr/local/bin|g" \
		-e "s|@includedir@|/usr/local/include/GL|g" \
		-e "s|@version@|2.2.0|g" \
		-e "s|@cflags@||g" \
		-e "s|@libname@|GLEW|g" \
		-e "s|@libgl@|-framework OpenGL|g" \
		-e "s|@requireslib@||g" \
		< glew.pc.in > glew.pc
$ cat glew.pc
prefix=/usr
exec_prefix=${prefix}
libdir=/usr/local/lib
includedir=${prefix}/include

Name: glew
Description: The OpenGL Extension Wrangler library
Version: 2.2.0
Cflags: -I${includedir}
Libs: -L${libdir} -lGLEW -framework OpenGL
Requires:
```