### PR TITLE
[parse_xml] replace OptionParser with ArgumentParser according to Python 3.2+ recommendation.

### DIFF
--- a/auto/bin/parse_xml.py
+++ b/auto/bin/parse_xml.py
@@ -127,33 +127,34 @@ def writeExtension(f, name, extension, enums, commands):
 
 if __name__ == '__main__':
 
-  from optparse import OptionParser
+  from argparse import ArgumentParser
   import os
 
-  parser = OptionParser('usage: %prog [options] [XML specs...]')
-  parser.add_option("--core", dest="core", help="location for core outputs", default='')
-  parser.add_option("--api", dest="name", help="API name: egl, wgl, glx, etc", default='')
-  parser.add_option("--extensions", dest="extensions", help="location for extensions outputs", default='')
+  parser = ArgumentParser(description='usage: %prog [options] [XML specs...]')
+  parser.add_argument("--core", dest="core", help="location for core outputs", default='')
+  parser.add_argument("--api", dest="name", help="API name: egl, wgl, glx, etc", default='')
+  parser.add_argument("--extensions", dest="extensions", help="location for extensions outputs", default='')
 
-  (options, args) = parser.parse_args()
+  (options, args) = parser.parse_known_args()
+  options = vars(options)
 
   for i in args:
 
     dom = parse(i)
-    api = findApi(dom, options.name)
+    api = findApi(dom, options['name'])
 
     print('Found {} enums, {} commands, {} features and {} extensions.'.format(
         len(api[0]), len(api[1]), len(api[2]), len(api[3])))
 
-    if len(options.core):
+    if len(options['core']):
         for i in api[2].keys():
-            f = open('%s/%s'%(options.core, i), 'wb')
+            f = open('%s/%s'%(options['core'], i), 'wb')
             writeExtension(f, i, api[2][i], api[0], api[1])
             f.close()
 
-    if len(options.extensions):
+    if len(options['extensions']):
         for i in api[3].keys():
-            f = open('%s/%s'%(options.extensions, i), 'wb')
+            f = open('%s/%s'%(options['extensions'], i), 'wb')
             writeExtension(f, i, api[3][i], api[0], api[1])
             f.close()
 

--- a/auto/bin/parse_xml.py
+++ b/auto/bin/parse_xml.py
@@ -98,7 +98,7 @@ def findApi(dom, name):
 isWGL = re.compile('WGL_([A-Z0-9]+)_.*')
 
 def writeExtension(f, name, extension, enums, commands):
-    f.write('%s\n'%name)
+    f.write(('%s\n'%name).encode())
 
     url = 'https://www.khronos.org/registry/egl/specs/eglspec.1.5.pdf'
 
@@ -106,24 +106,24 @@ def writeExtension(f, name, extension, enums, commands):
     if m:
         url = 'https://www.khronos.org/registry/OpenGL/extensions/%s/%s.txt'%(m.group(1), name)
 
-    f.write('%s\n'%(url))
+    f.write(('%s\n'%(url)).encode())
 
     if name.find('_VERSION_')==-1:
-        f.write('%s\n'%name)
+        f.write(('%s\n'%name).encode())
     else:
-        f.write('\n')
-    f.write('\n')
+        f.write('\n'.encode())
+    f.write('\n'.encode())
 
     enums = [ (j, enums[j]) for j in extension[0] ]
     for e in sorted(enums, key=lambda i: i[1]):
-        f.write('\t%s %s\n'%(e[0], e[1]))
+        f.write(('\t%s %s\n'%(e[0], e[1])).encode())
 
     commands = [ (j, commands[j]) for j in extension[1] ]
     for c in sorted(commands):
         params = ', '.join( [ '%s %s'%(j[0].strip(), j[1].strip()) for j in c[1][1] ] )
         if len(params)==0:
             params = 'void'
-        f.write('\t%s %s (%s)\n'%(c[1][0].strip(), c[0].strip(), params))
+        f.write(('\t%s %s (%s)\n'%(c[1][0].strip(), c[0].strip(), params)).encode())
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
Hello.

Starting from Python version 3.2 OptionParser is deprecated - instead ArgumentParser recommend to use, so proposed made such change in Python script parse_xml.

Thank you.
