### PR TITLE
Write files in binary format in parse_xml.py

### DIFF
--- a/auto/bin/parse_xml.py
+++ b/auto/bin/parse_xml.py
@@ -147,13 +147,13 @@ if __name__ == '__main__':
 
     if len(options.core):
         for i in api[2].keys():
-            f = open('%s/%s'%(options.core, i), 'w')
+            f = open('%s/%s'%(options.core, i), 'wb')
             writeExtension(f, i, api[2][i], api[0], api[1])
             f.close()
 
     if len(options.extensions):
         for i in api[3].keys():
-            f = open('%s/%s'%(options.extensions, i), 'w')
+            f = open('%s/%s'%(options.extensions, i), 'wb')
             writeExtension(f, i, api[3][i], api[0], api[1])
             f.close()
 


### PR DESCRIPTION
Issue:
On Windows platforms, when writing files with python in text-mode, LF characters get converted to CRLF.
This behavior leads to incorrect code generation in the steps following parse_xml.py

Fix:
Replace file access mode by 'wb' to avoid any platform-dependent behavior regarding newlines.