### PR TITLE
Extend GLEW_INCLUDE support to eglew.h and glxew.h

### DIFF
--- a/auto/src/eglew_head.h
+++ b/auto/src/eglew_head.h
@@ -27,7 +27,11 @@
 #include <KHR/khrplatform.h>
 #include <EGL/eglplatform.h>
 
-#include <GL/glew.h>
+#ifndef GLEW_INCLUDE
+#  include <GL/glew.h>
+#else
+#  include GLEW_INCLUDE
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -1,7 +1,7 @@
 #ifndef GLEW_INCLUDE
-#include <GL/glew.h>
+#  include <GL/glew.h>
 #else
-#include GLEW_INCLUDE
+#  include GLEW_INCLUDE
 #endif
 
 #if defined(GLEW_OSMESA)

--- a/auto/src/glxew_head.h
+++ b/auto/src/glxew_head.h
@@ -19,7 +19,12 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xmd.h>
-#include <GL/glew.h>
+
+#ifndef GLEW_INCLUDE
+#  include <GL/glew.h>
+#else
+#  include GLEW_INCLUDE
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
For #95 - support GLEW_INCLUDE for eglew.h and glxew.h also.