### PR TITLE
Blacklist GL_SGIX_fragment_specular_lighting

### DIFF
--- a/auto/blacklist
+++ b/auto/blacklist
@@ -7,6 +7,7 @@ EXT/object_space_tess.txt
 SGI/filter4_parameters.txt
 SGIS/SGIS_texture_color_mask.txt
 SGIX/SGIX_dmbuffer.txt
+SGIX/SGIX_fragment_specular_lighting.txt
 SGIX/SGIX_instruments.txt
 SGIX/SGIX_video_source.txt
 SGIX/SGIX_hyperpipe_group.txt


### PR DESCRIPTION
This extension conflicts with GL_SGIX_fragment_lighting from
the upstream glext.h. (That extension doesn't seem to be
documented in any extension registry, but only seems present
in glext.h.)

These two extensions have overlapping function names, but
GL_SGIX_fragment_specular_lighting has got incorrect use of
const on pointer arguments, causing compiler errors about
typedef redefinition with different types, if both glew.h
and glext.h are included.

E.g. the function glGetFragmentMaterialivSGIX is declared as
  glGetFragmentMaterialivSGIX (GLenum face, GLenum pname, GLint *params);
in glext.h, but is described as
  void GetFragmentMaterialivSGIX(enum face, enum pname, const int *data);
in SGIX_fragment_specular_lighting.txt.

Out of these two, SGIX_fragment_specular_lighting.txt clearly is
wrong (incomplete and probably never got used as such) as a getter
can't use a const pointer for writing the output parameters.