### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,17 @@ Snapshots may contain new features, bug-fixes or new OpenGL extensions ahead of 
 
 ## Build
 
-It is highly recommended to build from a tgz or zip release snapshot.
+You can download and build GLEW using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install glew
+
+The GLEW port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+It is highly recommended to build from a tgz or zip release snapshot or vcpkg.
 The code generation workflow is a complex brew of gnu make, perl and python, that works best on Linux or Mac.
 For most end-users of GLEW the official releases are the best choice, with first class support.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can download and build GLEW using the [vcpkg](https://github.com/Microsoft/v
     ./vcpkg integrate install
     vcpkg install glew
 
-The GLEW port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The GLEW port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository. If you would like to build vcpkg with telemetry disabled, use `./bootstrap-vcpkg.sh -disableMetrics` when bootstrapping.
 
 It is highly recommended to build from a tgz or zip release snapshot or vcpkg.
 The code generation workflow is a complex brew of gnu make, perl and python, that works best on Linux or Mac.


### PR DESCRIPTION
GLEW is available as a port in [vcpkg](https://github.com/Microsoft/vcpkg), a C++ library manager that simplifies installation for GLEW and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build GLEW, ready to be included in their projects. 

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/glew/portfile.cmake). We try to keep the library maintained as close as possible to the original library.