### PR TITLE
Do not put build artifacts in the source directory.

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -214,9 +214,9 @@ if (APPLE)
   set (requireslib)
 endif ()
 
-configure_file (${GLEW_DIR}/glew.pc.in ${GLEW_DIR}/glew.pc @ONLY)
+configure_file (${GLEW_DIR}/glew.pc.in ${CMAKE_CURRENT_BINARY_DIR}/glew.pc @ONLY)
 
-install(FILES ${GLEW_DIR}/glew.pc
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/glew.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 


### PR DESCRIPTION
Files generated during the build and other build artifacts should not be placed in the Source Directory. This can cause conflicts when building different targets from the same souce tree . This patch generates the glew.pc file in the CMAKE_CURRENT_BINARY_DIRECTORY instead which allows each build to have its own copy.