### PR TITLE
docs: fix simple typo, direcly -> directly

### DIFF
--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -28,7 +28,7 @@
 #if defined(GLEW_EGL)
 #elif defined(GLEW_REGAL)
 
-/* In GLEW_REGAL mode we call direcly into the linked
+/* In GLEW_REGAL mode we call directly into the linked
    libRegal.so glGetProcAddressREGAL for looking up
    the GL function pointers. */
 


### PR DESCRIPTION
There is a small typo in auto/src/glew_head.c.

Should read `directly` rather than `direcly`.

