### PR TITLE
The file include/GL/gl.h generated from OpenGL-Registry uses __gl_gl_h_

### DIFF
--- a/auto/src/glew_head.h
+++ b/auto/src/glew_head.h
@@ -2,7 +2,7 @@
 #define __glew_h__
 #define __GLEW_H__
 
-#if defined(__gl_h_) || defined(__GL_H__) || defined(_GL_H) || defined(__X_GL_H)
+#if defined(__gl_h_) || defined(__GL_H__) || defined(_GL_H) || defined(__gl_gl_h_) || defined(__X_GL_H)
 #error gl.h included before glew.h
 #endif
 #if defined(__gl2_h_)
@@ -25,6 +25,7 @@
 #define __gl2_h_
 #define __GL_H__
 #define _GL_H
+#define __gl_gl_h_
 #define __gltypes_h_
 #define __REGAL_H__
 #define __X_GL_H


### PR DESCRIPTION
This change is similar to commit https://github.com/nigels-com/glew/commit/7f65a36866f4e24dd1446fe1c9d21424f28bcabd

Nicolas Caramelli