### PR TITLE
Add support for building against vendor-neutral GLVND on Linux/EGL

### DIFF
--- a/config/Makefile.linux-egl-glvnd
+++ b/config/Makefile.linux-egl-glvnd
@@ -1,0 +1,4 @@
+include config/Makefile.linux
+
+LDFLAGS.GL = -lEGL -lOpenGL
+CFLAGS.EXTRA += -DGLEW_EGL


### PR DESCRIPTION
The correct way to link against OpenGL on modern GNU/Linux systems (ie: X11 is a legacy windows server, there could be no windows server at all, etc) is not linking against GLX (-lGL) but using vendor-neutral GLVND (-lOpenGL).
This is what this new Makefile does. So building with:

`make SYSTEM=linux-egl-glvnd`

...is the way.