### PR TITLE
Specify that EGL/GLVND doesn't use GLU.

### DIFF
--- a/config/Makefile.linux-egl-glvnd
+++ b/config/Makefile.linux-egl-glvnd
@@ -2,3 +2,4 @@ include config/Makefile.linux
 
 LDFLAGS.GL = -lEGL -lOpenGL
 CFLAGS.EXTRA += -DGLEW_EGL
+GLEW_NO_GLU = -DGLEW_NO_GLU


### PR DESCRIPTION
EGL/GLVND doesn't use GLU at all, since GLU is an old and X11-only solution.