### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ _Note: you may need to call `make` in the  **auto** folder first_
 
 #### Using cmake
 
-The cmake build is mostly contributer maintained.
+The cmake build is mostly contributor maintained.
 Due to the multitude of use cases this is maintained on a _best effort_ basis.
 Pull requests are welcome.
 

--- a/auto/bin/parse_spec.pl
+++ b/auto/bin/parse_spec.pl
@@ -114,7 +114,7 @@ my %taboo_tokens = (
 );
 
 # list of function definitions to be ignored, unless they are being defined in
-# the given spec.  This is an ugly hack arround the fact that people writing
+# the given spec.  This is an ugly hack around the fact that people writing
 # spec files seem to shut down all brain activity while they are at this task.
 #
 # This will be moved to its own file eventually.
@@ -185,7 +185,7 @@ sub normalize_prototype
     return $_;
 }
 
-# Ugly hack to work arround the fact that functions are declared in more
+# Ugly hack to work around the fact that functions are declared in more
 # than one spec file.
 sub ignore_function($$)
 {

--- a/auto/doc/advanced.html
+++ b/auto/doc/advanced.html
@@ -88,7 +88,7 @@ terminated with a semicolon.
 <h3>Custom Code Generation</h3>
 <p>
 Starting from GLEW 1.3.0, it is possible to control which extensions
-to include in the libarary by specifying a list in
+to include in the library by specifying a list in
 <tt>auto/custom.txt</tt>. This is useful when you do not need all the
 extensions and would like to reduce the size of the source files.
 Type <tt>make clean; make custom</tt> in the <tt>auto</tt> directory

--- a/auto/doc/log.html
+++ b/auto/doc/log.html
@@ -198,7 +198,7 @@
 <ul>
 <li> Bug fixes:
 <ul>
-<li> Resovled crash when glXGetCurrentDisplay() is NULL
+<li> Resolved crash when glXGetCurrentDisplay() is NULL
 <li> CMake: only install PDB files with MSVC
 <li> wglGetProcAddress crash with NOGDI defined 
 <li> Mac: using -Os rather than -O2
@@ -927,7 +927,7 @@
 </ul>
 <li> Bug fixes:
 <ul>
-<li> Incorrent 64-bit type definitions
+<li> Incorrect 64-bit type definitions
 <li> Do not strip static library on install
 <li> Missing tokens in GL_ATI_fragment_shader and WGL_{ARB,EXT}_make_current_read
 <li> Missing tokens in GL_VERSION_2_1
@@ -975,7 +975,7 @@ corruption of their values
 <li> Missing include guards in glxew.h
 <li> Makefile and install problems for Cygwin builds
 <li> Install problem for Linux AMD64 builds
-<li> Incorrent token in GL_ATI_texture_compression_3dc
+<li> Incorrect token in GL_ATI_texture_compression_3dc
 <li> Missing tokens from GL_ATIX_point_sprites
 </ul>
 </ul>

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 
 find_package (OpenGL REQUIRED)
 
-# cmake<3.10 doesnt detect EGL/GLX
+# cmake<3.10 doesn't detect EGL/GLX
 if (CMAKE_VERSION VERSION_LESS 3.10)
   find_library(OPENGL_egl_LIBRARY NAMES EGL)
   if (OPENGL_egl_LIBRARY)

--- a/doc/advanced.html
+++ b/doc/advanced.html
@@ -184,7 +184,7 @@ terminated with a semicolon.
 <h3>Custom Code Generation</h3>
 <p>
 Starting from GLEW 1.3.0, it is possible to control which extensions
-to include in the libarary by specifying a list in
+to include in the library by specifying a list in
 <tt>auto/custom.txt</tt>. This is useful when you do not need all the
 extensions and would like to reduce the size of the source files.
 Type <tt>make clean; make custom</tt> in the <tt>auto</tt> directory

--- a/doc/log.html
+++ b/doc/log.html
@@ -294,7 +294,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 <ul>
 <li> Bug fixes:
 <ul>
-<li> Resovled crash when glXGetCurrentDisplay() is NULL
+<li> Resolved crash when glXGetCurrentDisplay() is NULL
 <li> CMake: only install PDB files with MSVC
 <li> wglGetProcAddress crash with NOGDI defined 
 <li> Mac: using -Os rather than -O2
@@ -1023,7 +1023,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 </ul>
 <li> Bug fixes:
 <ul>
-<li> Incorrent 64-bit type definitions
+<li> Incorrect 64-bit type definitions
 <li> Do not strip static library on install
 <li> Missing tokens in GL_ATI_fragment_shader and WGL_{ARB,EXT}_make_current_read
 <li> Missing tokens in GL_VERSION_2_1
@@ -1071,7 +1071,7 @@ corruption of their values
 <li> Missing include guards in glxew.h
 <li> Makefile and install problems for Cygwin builds
 <li> Install problem for Linux AMD64 builds
-<li> Incorrent token in GL_ATI_texture_compression_3dc
+<li> Incorrect token in GL_ATI_texture_compression_3dc
 <li> Missing tokens from GL_ATIX_point_sprites
 </ul>
 </ul>


### PR DESCRIPTION
Found via `codespell -q 3 -L ake,extrem,lod,parms`