### PR TITLE
SYSTEM=linux-wayland build config for EGL without X11

### DIFF
--- a/config/Makefile.linux-wayland
+++ b/config/Makefile.linux-wayland
@@ -1,0 +1,4 @@
+include config/Makefile.linux
+
+LDFLAGS.GL = -lEGL -lGL
+CFLAGS.EXTRA += -DGLEW_EGL -DEGL_NO_X11


### PR DESCRIPTION
```
$ make SYSTEM=linux-wayland
...
$ ldd -r lib/libGLEW.so
	linux-vdso.so.1 (0x00007ffd9cf53000)
	libEGL.so.1 => /lib/x86_64-linux-gnu/libEGL.so.1 (0x00007f7c7bc3f000)
	libGLdispatch.so.0 => /lib/x86_64-linux-gnu/libGLdispatch.so.0 (0x00007f7c7bb87000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f7c7bb81000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f7c7b98f000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f7c7bd25000)
```