### PR TITLE
Make: Support Apple Silicon in Universal Build

### DIFF
--- a/config/Makefile.darwin-universal
+++ b/config/Makefile.darwin-universal
@@ -1,5 +1,5 @@
 #
-# Needs to be clang toolchain for universal: -arch i386 -arch x86_64 -arch arm64
+# Needs to be clang toolchain for universal: -arch x86_64 -arch arm64
 #
 GLEW_DEST = /usr/local
 NAME = $(GLEW_NAME)
@@ -11,8 +11,8 @@ STRIP =
 CFLAGS.EXTRA = -dynamic -fno-common
 CFLAGS.EXTRA += -pedantic
 CFLAGS.EXTRA += -fPIC
-CFLAGS.EXTRA += -arch i386 -arch x86_64 -arch arm64
-LDFLAGS.EXTRA = -arch i386 -arch x86_64 -arch arm64
+CFLAGS.EXTRA += -arch x86_64 -arch arm64
+LDFLAGS.EXTRA = -arch x86_64 -arch arm64
 ifneq (undefined, $(origin GLEW_APPLE_GLX))
 CFLAGS.EXTRA += -std=c99
 CFLAGS.EXTRA += -I/usr/X11R6/include -D'GLEW_APPLE_GLX'

--- a/config/Makefile.darwin-universal
+++ b/config/Makefile.darwin-universal
@@ -1,5 +1,5 @@
 #
-# Needs to be clang toolchain for universal: -arch i386 -arch x86_64
+# Needs to be clang toolchain for universal: -arch i386 -arch x86_64 -arch arm64
 #
 GLEW_DEST = /usr/local
 NAME = $(GLEW_NAME)
@@ -11,8 +11,8 @@ STRIP =
 CFLAGS.EXTRA = -dynamic -fno-common
 CFLAGS.EXTRA += -pedantic
 CFLAGS.EXTRA += -fPIC
-CFLAGS.EXTRA += -arch i386 -arch x86_64
-LDFLAGS.EXTRA = -arch i386 -arch x86_64
+CFLAGS.EXTRA += -arch i386 -arch x86_64 -arch arm64
+LDFLAGS.EXTRA = -arch i386 -arch x86_64 -arch arm64
 ifneq (undefined, $(origin GLEW_APPLE_GLX))
 CFLAGS.EXTRA += -std=c99
 CFLAGS.EXTRA += -I/usr/X11R6/include -D'GLEW_APPLE_GLX'


### PR DESCRIPTION
👋 Hi,

this pull request adds Apple Silicon support to the Makefile for universal Mac builds. If I should change anything in the pull request, then please just comment below. Thank you.

---

BTW: Is there an easy way to only install the static version of the library? I was able to build the static version of GLEW with:

```sh
make -C auto
export MACOSX_DEPLOYMENT_TARGET=10.9 GLEW_DEST=/usr/local
make SYSTEM=darwin-universal glew.lib.static
```

However, installing the library with:

```
sudo make install
```

failed with the following error message on my machine:

```sh
install -d -m 0755 "/usr/local/include/GL"
install -m 0644 include/GL/wglew.h "/usr/local/include/GL/"
install -m 0644 include/GL/glew.h "/usr/local/include/GL/"
install -m 0644 include/GL/glxew.h "/usr/local/include/GL/"
install -m 0644 include/GL/eglew.h "/usr/local/include/GL/"
cc -DGLEW_NO_GLU -DGLEW_BUILD -Os -Wall -W -Iinclude -dynamic -fno-common -pedantic -fPIC -std=c89  -o tmp/darwin/default/shared/glew.o -c src/glew.c
cc -dynamiclib -install_name /usr/local/lib/libGLEW.2.2.0.dylib -current_version 2.2.0 -compatibility_version 2.2 -o lib/libGLEW.2.2.0.dylib tmp/darwin/default/shared/glew.o  -framework OpenGL
ln -sf libGLEW.2.2.0.dylib lib/libGLEW.2.2.dylib
ln -sf libGLEW.2.2.0.dylib lib/libGLEW.dylib
strip -x lib/libGLEW.2.2.0.dylib
sed \
		-e "s|@prefix@|/usr/local|g" \
		-e "s|@libdir@|/usr/local/lib|g" \
		-e "s|@exec_prefix@|/usr/local/bin|g" \
		-e "s|@includedir@|/usr/local/include/GL|g" \
		-e "s|@version@|2.2.0|g" \
		-e "s|@cflags@||g" \
		-e "s|@libname@|GLEW|g" \
		-e "s|@libgl@|-framework OpenGL|g" \
		-e "s|@requireslib@||g" \
		< glew.pc.in > glew.pc
cc -DGLEW_NO_GLU -DGLEW_STATIC -Os -Wall -W -Iinclude -dynamic -fno-common -pedantic -fPIC -std=c89  -o tmp/darwin/default/static/glew.o -c src/glew.c
ar rv lib/libGLEW.a tmp/darwin/default/static/glew.o
ar: lib/libGLEW.a is a fat file (use libtool(1) or lipo(1) and ar(1) on it)
ar: lib/libGLEW.a: Inappropriate file type or format
make: *** [lib/libGLEW.a] Error 1
```

For now I just used the following commands as workaround:

```sh
sudo make install.include
sudo cp lib/libGLEW.a /usr/local/lib
```