### PR TITLE
Fixed failing build on Windows when using LLVM due to non-ASCII codepoint for copyright symbol

### DIFF
--- a/auto/src/glew.rc
+++ b/auto/src/glew.rc
@@ -19,7 +19,7 @@
 //
 // Version
 //
-VS_VERSION_INFO VERSIONINFO 
+VS_VERSION_INFO VERSIONINFO
 FILEVERSION GLEW_MAJOR, GLEW_MINOR, GLEW_MICRO, 0
 PRODUCTVERSION GLEW_MAJOR, GLEW_MINOR, GLEW_MICRO, 0
 FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
@@ -40,7 +40,7 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "Comments", 
+            VALUE "Comments",
             "The OpenGL Extension Wrangler Library\r\n"
             "Copyright (C) 2008-2019, Nigel Stewart <nigels[]users sourceforge net>\r\n"
             "Copyright (C) 2002-2008, Milan Ikits <milan ikits[]ieee org>\r\n"
@@ -120,7 +120,7 @@ BEGIN
             VALUE "FileDescription", "The OpenGL Extension Wrangler Library\0"
             VALUE "FileVersion", "GLEW_MAJOR,GLEW_MINOR,GLEW_MICRO,0\0"
             VALUE "InternalName", "GLEW\0"
-            VALUE "LegalCopyright", "© 2002-2019 Nigel Stewart & Milan Ikits & Marcelo Magallon\0"
+            VALUE "LegalCopyright", "(C) 2002-2019 Nigel Stewart & Milan Ikits & Marcelo Magallon\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", FILENAME "\0"
             VALUE "PrivateBuild", "\0"

--- a/auto/src/glewinfo.rc
+++ b/auto/src/glewinfo.rc
@@ -11,7 +11,7 @@
 //
 // Version
 //
-VS_VERSION_INFO VERSIONINFO 
+VS_VERSION_INFO VERSIONINFO
 FILEVERSION GLEW_MAJOR, GLEW_MINOR, GLEW_MICRO, 0
 PRODUCTVERSION GLEW_MAJOR, GLEW_MINOR, GLEW_MICRO, 0
 FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
@@ -28,7 +28,7 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "Comments", 
+            VALUE "Comments",
             "The OpenGL Extension Wrangler Library\r\n"
             "Copyright (C) 2008-2019, Nigel Stewart <nigels[]users sourceforge net>\r\n"
             "Copyright (C) 2002-2008, Milan Ikits <milan ikits[]ieee org>\r\n"
@@ -108,7 +108,7 @@ BEGIN
             VALUE "FileDescription", "Utility for verifying extension entry points\0"
             VALUE "FileVersion", "GLEW_MAJOR,GLEW_MINOR,GLEW_MICRO,0\0"
             VALUE "InternalName", "glewinfo\0"
-            VALUE "LegalCopyright", "© 2002-2019 Nigel Stewart & Milan Ikits & Marcelo Magallon\0"
+            VALUE "LegalCopyright", "(C) 2002-2019 Nigel Stewart & Milan Ikits & Marcelo Magallon\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", FILENAME "\0"
             VALUE "PrivateBuild", "\0"

--- a/auto/src/visualinfo.rc
+++ b/auto/src/visualinfo.rc
@@ -11,7 +11,7 @@
 //
 // Version
 //
-VS_VERSION_INFO VERSIONINFO 
+VS_VERSION_INFO VERSIONINFO
 FILEVERSION GLEW_MAJOR, GLEW_MINOR, GLEW_MICRO, 0
 PRODUCTVERSION GLEW_MAJOR, GLEW_MINOR, GLEW_MICRO, 0
 FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
@@ -28,7 +28,7 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "Comments", 
+            VALUE "Comments",
             "The OpenGL Extension Wrangler Library\r\n"
             "Copyright (C) 2008-2019, Nigel Stewart <nigels[]users sourceforge net>\r\n"
             "Copyright (C) 2002-2008, Milan Ikits <milan ikits[]ieee org>\r\n"
@@ -108,7 +108,7 @@ BEGIN
             VALUE "FileDescription", "Utility for listing pixelformat capabilities\0"
             VALUE "FileVersion", "GLEW_MAJOR,GLEW_MINOR,GLEW_MICRO,0\0"
             VALUE "InternalName", "visualinfo\0"
-            VALUE "LegalCopyright", "© 2002-2019 Nigel Stewart & Milan Ikits & Marcelo Magallon\0"
+            VALUE "LegalCopyright", "(C) 2002-2019 Nigel Stewart & Milan Ikits & Marcelo Magallon\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", FILENAME "\0"
             VALUE "PrivateBuild", "\0"


### PR DESCRIPTION
# Context

While attempting to build GLEW on Windows 11 using Clang and CMake I ran into a strange issue. The build would fail on trying to compile any RC file using `llvm-rc` with the error `Non-ASCII 8-bit codepoint (�) can't be interpreted in the current codepage`. After looking around in my editor with it set to UTF-8 mode I spotted a symbol that wasn't showing up right. Comparing it to the GitHub representation I realized it was the copyright symbol.

This PR changes the non-ASCII codepoint for the copyright symbol in all three RC files to `(C)` as used elsewhere in the same files.