### PR TITLE
Fix issue #355 - GL_NVX_progress_fence missing glCreateProgressFenceNVX

### DIFF
--- a/auto/bin/filter_gl_ext.sh
+++ b/auto/bin/filter_gl_ext.sh
@@ -481,8 +481,9 @@ EOT
     head -n4 $1/GL_AMD_gpu_shader_int64 > tmp
     mv tmp $1/GL_AMD_gpu_shader_int64
 
-# Filter out GL_NO_ERROR enum from GL_KHR_robustness
-    grep -v 'GL_NO_ERROR' $1/GL_KHR_robustness > tmp
+# Filter out GL_NO_ERROR enum and glGetGraphicsResetStatus from GL_KHR_robustness
+    grep -v 'GL_NO_ERROR'              $1/GL_KHR_robustness |
+    grep -v 'glGetGraphicsResetStatus' > tmp
     mv tmp $1/GL_KHR_robustness
 
 # Filter out all enums from GL_KHR_blend_equation_advanced_coherent

--- a/auto/bin/make.pl
+++ b/auto/bin/make.pl
@@ -10,7 +10,7 @@
 my %regex = (
     extname  => qr/^[A-Z][A-Za-z0-9_]+$/,
     exturl   => qr/^http.+$/,
-    function => qr/^(.+) ([a-z][a-z0-9_]*) \((.+)\)$/i, 
+    function => qr/^(.+) ([a-z][a-z0-9_]*) \((.*)\)$/i,
     token    => qr/^([A-Z][A-Z0-9_x]*)\s+((?:0x)?[0-9A-Fa-f]+(u(ll)?)?|[A-Z][A-Z0-9_]*)$/,
     type     => qr/^typedef\s+(.+)$/,
     exact    => qr/.*;$/,

--- a/auto/bin/parse_spec.pl
+++ b/auto/bin/parse_spec.pl
@@ -158,7 +158,7 @@ my %regex = (
     eofnc    => qr/(?:\);?$|^$)/, # )$ | );$ | ^$
     extname  => qr/^[A-Z][A-Za-z0-9_]+$/,
     none     => qr/^\(none\)$/,
-    function => qr/^(.+) ([a-z][a-z0-9_]*) \((.+)\)$/i,
+    function => qr/^(.+) ([a-z][a-z0-9_]*) \((.*)\)$/i,
     prefix   => qr/^(?:[aw]?gl|glX|egl)/, # gl | agl | wgl | glX
     tprefix  => qr/^(?:[AW]?GL|GLX|EGL)_/, # GL_ | AGL_ | WGL_ | GLX_
     section  => compile_regex('^(', join('|', @sections), ')$'), # sections in spec
@@ -258,6 +258,10 @@ sub parse_spec($)
                             $parms =~ s/$regex{voidtype}/$voidtypemap{$1}/og;
                             $parms =~ s/GLvoid/void/og;
                             $parms =~ s/ void\* / void */og;
+                            if ($parms eq "")
+                            {
+                                $parms = "void";  # NVX_progress_fence and others
+                            }
                         }
                         # add to functions hash
                         $functions{$name} = {


### PR DESCRIPTION
For Issue #355 

The code generation was not supporting empty parameter lists.
Proposed fix here is to treat `()` as `(void)`