### PR TITLE
Remove broken end of string checks in _glewStrSame

### DIFF
--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -221,7 +221,7 @@ static GLboolean _glewStrSame1 (const GLubyte** a, GLuint* na, const GLubyte* b,
   if(*na >= nb)
   {
     GLuint i=0;
-    while (i < nb && (*a)+i != NULL && b+i != NULL && (*a)[i] == b[i]) i++;
+    while (i < nb && (*a)[i] == b[i]) i++;
     if(i == nb)
     {
       *a = *a + nb;
@@ -237,7 +237,7 @@ static GLboolean _glewStrSame2 (const GLubyte** a, GLuint* na, const GLubyte* b,
   if(*na >= nb)
   {
     GLuint i=0;
-    while (i < nb && (*a)+i != NULL && b+i != NULL && (*a)[i] == b[i]) i++;
+    while (i < nb && (*a)[i] == b[i]) i++;
     if(i == nb)
     {
       *a = *a + nb;
@@ -253,7 +253,7 @@ static GLboolean _glewStrSame3 (const GLubyte** a, GLuint* na, const GLubyte* b,
   if(*na >= nb)
   {
     GLuint i=0;
-    while (i < nb && (*a)+i != NULL && b+i != NULL && (*a)[i] == b[i]) i++;
+    while (i < nb && (*a)[i] == b[i]) i++;
     if (i == nb && (*na == nb || (*a)[i] == ' ' || (*a)[i] == '\n' || (*a)[i] == '\r' || (*a)[i] == '\t'))
     {
       *a = *a + nb;


### PR DESCRIPTION
I think this code tried to check for a zero terminated null byte, but it
actually just checked if the address of the corresponding character is
non-zero, which is always true. These broken checks are simply dropped
because the following code assumes that the string `b` doesn't include a
null byte and all call sites already pass the length of the string
without counting the null byte.

This bug was found by gcc 12.1 which emits a warning on this kind of
code. Now glew builds without any warnings using gcc 12.1. See
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102103 for the
corresponding issue.