### PR TITLE
Handle expanded tokens

### DIFF
--- a/auto/bin/make.pl
+++ b/auto/bin/make.pl
@@ -11,7 +11,7 @@ my %regex = (
     extname  => qr/^[A-Z][A-Za-z0-9_]+$/,
     exturl   => qr/^http.+$/,
     function => qr/^(.+) ([a-z][a-z0-9_]*) \((.*)\)$/i,
-    token    => qr/^([A-Z][A-Z0-9_x]*)\s+((?:0x)?[0-9A-Fa-f]+(u(ll)?)?|[A-Z][A-Z0-9_]*)$/,
+    token    => qr/^([A-Z][A-Za-z0-9_x]*)\s+((?:0x|-)?[0-9A-Fa-f]+(u(ll)?)?|[A-Z][A-Za-z0-9(),_-]*)$/,
     type     => qr/^typedef\s+(.+)$/,
     exact    => qr/.*;$/,
 );


### PR DESCRIPTION
Extensions, especially EGL, now have tokens like:

```
EGL_TIMESTAMP_PENDING_ANDROID EGL_CAST(EGLnsecsANDROID,-2)
EGL_COLORSPACE_sRGB 0x3089
EGL_NO_NATIVE_FENCE_FD_ANDROID -1
```

This expands the tokens regex to handle them.

Unfortunately this now leads to warnings like:

```
include/GL/eglew.h:186:9: warning: 'EGL_NO_SURFACE' macro redefined [-Wmacro-redefined]
#define EGL_NO_SURFACE EGL_CAST(EGLSurface,0)
        ^
include/GL/eglew.h:170:9: note: previous definition is here
#define EGL_NO_SURFACE                    ((EGLSurface)0)
```

I think the non-EGL_CAST version comes from `auto/glfixes` but I don't know if the fix is to just delete these entries from there?  `EGL_CAST` is in `eglplatform` so no issues with having things defined in terms of it.
