### PR TITLE
Added to .gitignore auto-checkedout repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 /tmp
 /out
 .DS_Store*
+auto/EGL-Registry
+auto/OpenGL-Registry
+auto/glfixes


### PR DESCRIPTION
These three directories are automatically created when running `make extensions` so it makes sense to add them to gitignore.