### PR TITLE
Check the macOS deployment target before using dlfcn.h

### DIFF
--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -70,7 +70,7 @@ void* dlGetProcAddress (const GLubyte* name)
 #include <string.h>
 #include <AvailabilityMacros.h>
 
-#ifdef MAC_OS_X_VERSION_10_3
+#if defined(MAC_OS_X_VERSION_10_3) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_3
 
 #include <dlfcn.h>
 
@@ -120,7 +120,7 @@ void* NSGLGetProcAddress (const GLubyte *name)
   return NULL;
 #endif
 }
-#endif /* MAC_OS_X_VERSION_10_3 */
+#endif /* defined(MAC_OS_X_VERSION_10_3) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_3 */
 #endif /* __APPLE__ */
 
 /*


### PR DESCRIPTION
The header that checks if dlfcn.h is available currently checks if MAC_OS_X_VERSION_10_3 is defined, but it doesn't check if the deployment target is greater or equal to macOS 10.3. This PR adds a check for the deployment target.