### PR TITLE
Remove everything after digits in SYSTEM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@
 include config/version
 
 SHELL = /bin/sh
-SYSTEM ?= $(shell config/config.guess | cut -d - -f 3 | sed -e 's/[0-9\.]//g;')
+SYSTEM ?= $(shell config/config.guess | cut -d - -f 3 | sed -e 's/\.//g' -e 's/[0-9]\{1,\}.*//')
 SYSTEM.SUPPORTED = $(shell test -f config/Makefile.$(SYSTEM) && echo 1)
 
 ifeq ($(SYSTEM.SUPPORTED), 1)


### PR DESCRIPTION
Instead of just removing periods and digits from SYSTEM, remove periods and digits and everything after any digits. This handles unusual system identifiers like `powerpc-apple-darwin10.0.0d2`.

I wasn't sure if periods can appear anywhere other than in the release number so I retained the previous behavior of removing all periods regardless where they are.