### PR TITLE
Shallow clone of registry repositories

### DIFF
--- a/auto/Makefile
+++ b/auto/Makefile
@@ -92,15 +92,15 @@ OpenGL-Registry/.dummy:
 	@echo "--------------------------------------------------------------------"
 	@echo "Downloading OpenGL-Registry"
 	@echo "--------------------------------------------------------------------"
-	git clone $(REPO_OPENGL) OpenGL-Registry
-	git clone --branch glew $(REPO_GLFIXES) glfixes
+	git clone --depth=1 $(REPO_OPENGL) OpenGL-Registry
+	git clone --depth=1 --branch glew $(REPO_GLFIXES) glfixes
 	touch $@
 
 EGL-Registry/.dummy:
 	@echo "--------------------------------------------------------------------"
 	@echo "Downloading EGL-Registry"
 	@echo "--------------------------------------------------------------------"
-	git clone $(REPO_EGL) EGL-Registry
+	git clone --depth=1 $(REPO_EGL) EGL-Registry
 	touch $@
 
 $(EXT)/.dummy: OpenGL-Registry/.dummy EGL-Registry/.dummy


### PR DESCRIPTION
# Issue 
Executing `make` from `auto` fails because `OpenGL-Registry` is a large repository (in size), as shown in the snippet below. 

```
--------------------------------------------------------------------
Downloading OpenGL-Registry
--------------------------------------------------------------------
git clone https://github.com/KhronosGroup/OpenGL-Registry.git OpenGL-Registry
Cloning into 'OpenGL-Registry'...
error: RPC failed; result=18, HTTP code = 200
fatal: The remote end hung up unexpectedly
fatal: early EOF
fatal: index-pack failed
make: *** [Makefile:95: OpenGL-Registry/.dummy] Error 128
```

# Solution
Given that we seem only to require the last commit from that repository, I'm proposing to make the clone shallow so we only get the last versions of all the files in the repository.

It's possible to unshallow later if required by a future unimplemented operation.
