### PR TITLE
CMake: fix initialization of CMakeLists and cleanup after bump of min cmake version

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -1,24 +1,11 @@
+cmake_minimum_required(VERSION 3.16)
+project(glew LANGUAGES C)
+
 if ( NOT DEFINED CMAKE_BUILD_TYPE )
   set( CMAKE_BUILD_TYPE Release CACHE STRING "Build type" )
 endif ()
 
-project (glew C)
-
-cmake_minimum_required (VERSION 3.16)
-
 include(GNUInstallDirs)
-
-if(POLICY CMP0003)
-  cmake_policy (SET CMP0003 NEW)
-endif()
-
-if(POLICY CMP0042)
-  cmake_policy (SET CMP0042 NEW)
-endif()
-
-if (POLICY CMP0072)
-  cmake_policy (SET CMP0072 NEW)
-endif(POLICY CMP0072)
 
 set(CMAKE_DEBUG_POSTFIX d)
 
@@ -50,14 +37,6 @@ if (NOT GLEW_CUSTOM_OUTPUT_DIRS)
 endif()
 
 find_package (OpenGL REQUIRED)
-
-# cmake<3.10 doesn't detect EGL/GLX
-if (CMAKE_VERSION VERSION_LESS 3.10)
-  find_library(OPENGL_egl_LIBRARY NAMES EGL)
-  if (OPENGL_egl_LIBRARY)
-    set (OpenGL_EGL_FOUND TRUE)
-  endif ()
-endif ()
 
 # prefer GLVND
 if (OPENGL_opengl_LIBRARY)
@@ -178,15 +157,11 @@ endif()
 target_link_libraries (glew LINK_PUBLIC ${GLEW_LIBRARIES})
 target_link_libraries (glew_s ${GLEW_LIBRARIES})
 
-if(CMAKE_VERSION VERSION_LESS 2.8.12)
-  set(MAYBE_EXPORT "")
-else()
-  target_compile_definitions(glew_s INTERFACE "GLEW_STATIC")
-  foreach(t glew glew_s)
-    target_include_directories(${t} PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-  endforeach()
-  set(MAYBE_EXPORT EXPORT glew-targets)
-endif()
+target_compile_definitions(glew_s INTERFACE "GLEW_STATIC")
+foreach(t glew glew_s)
+  target_include_directories(${t} PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+endforeach()
+set(MAYBE_EXPORT EXPORT glew-targets)
 
 set(targets_to_install "")
 if(BUILD_SHARED_LIBS)
@@ -258,7 +233,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/glew.pc
         COMPONENT Development
 )
 
-if(WIN32 AND MSVC AND (NOT MSVC_VERSION LESS 1600) AND (NOT CMAKE_VERSION VERSION_LESS "3.1"))
+if(WIN32 AND MSVC AND (NOT MSVC_VERSION LESS 1600))
     install(
         FILES $<TARGET_PDB_FILE:glew>
         DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -161,7 +161,6 @@ target_compile_definitions(glew_s INTERFACE "GLEW_STATIC")
 foreach(t glew glew_s)
   target_include_directories(${t} PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 endforeach()
-set(MAYBE_EXPORT EXPORT glew-targets)
 
 set(targets_to_install "")
 if(BUILD_SHARED_LIBS)
@@ -171,7 +170,7 @@ else ()
 endif()
 
 install ( TARGETS ${targets_to_install}
-          ${MAYBE_EXPORT}
+          EXPORT glew-targets
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Runtime
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development
@@ -247,16 +246,14 @@ install (
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/GL
     COMPONENT Development)
 
-if(MAYBE_EXPORT)
-  install(EXPORT glew-targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/glew
-    COMPONENT Development
-    NAMESPACE GLEW::)
-  install(FILES
-      ${CMAKE_CURRENT_SOURCE_DIR}/glew-config.cmake
-      ${CMAKE_CURRENT_SOURCE_DIR}/CopyImportedTargetProperties.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/glew
-    COMPONENT Development)
-endif()
+install(EXPORT glew-targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/glew
+  COMPONENT Development
+  NAMESPACE GLEW::)
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/glew-config.cmake
+    ${CMAKE_CURRENT_SOURCE_DIR}/CopyImportedTargetProperties.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/glew
+  COMPONENT Development)
 
 if(NOT TARGET uninstall)
   configure_file(

--- a/build/cmake/testbuild/CMakeLists.txt
+++ b/build/cmake/testbuild/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(glew-cmake-test)
+cmake_minimum_required(VERSION 3.16)
+project(glew-cmake-test LANGUAGES C)
 
 find_package(GLEW REQUIRED CONFIG)
 find_package(GLEW REQUIRED CONFIG) # call twice to test multiple call
@@ -10,14 +10,8 @@ set_target_properties(cmake-test PROPERTIES DEBUG_POSTFIX _d)
 target_link_libraries(cmake-test PRIVATE GLEW::GLEW ${OPENGL_LIBRARIES})
 target_include_directories(cmake-test PRIVATE ${OPENGL_INCLUDE_DIR})
 
-if(CMAKE_VERSION VERSION_LESS 3.0)
-    set(cgex $<CONFIGURATION>)
-else()
-    set(cgex $<CONFIG>)
-endif()
-
 target_compile_definitions(cmake-test PRIVATE
-    -DGLEW_CMAKE_TEST_CONFIG=${cgex}
+    -DGLEW_CMAKE_TEST_CONFIG=$<CONFIG>
     -DGLEW_CMAKE_TEST_TARGET_FILE_NAME=$<TARGET_FILE_NAME:GLEW::GLEW>
     -DGLEW_CMAKE_TEST_TARGET_TYPE=$<TARGET_PROPERTY:GLEW::GLEW,TYPE>
     )


### PR DESCRIPTION
closes https://github.com/nigels-com/glew/issues/395

also remove dead code in CMakeLists as a consequence of https://github.com/nigels-com/glew/pull/391

Forcing CMP0003, CMP0042 and CMP0072 to NEW is useless now, since it's already their value after bump of cmake_minimum_required