### PR TITLE
blacklist MESA_sampler_objects for now, collides with GL_ARB_sampler_objects

### DIFF
--- a/auto/blacklist
+++ b/auto/blacklist
@@ -4,6 +4,7 @@ EXT/vertex_array_set.alt.txt
 EXT/vertex_array_set.txt
 EXT/nurbs_tessellator.txt
 EXT/object_space_tess.txt
+MESA/MESA_sampler_objects.txt
 SGI/filter4_parameters.txt
 SGIS/SGIS_texture_color_mask.txt
 SGIX/SGIX_dmbuffer.txt


### PR DESCRIPTION
As reported in #399 and PR #400 there was addition upstream of [GL_MESA_sampler_objects](https://github.com/KhronosGroup/OpenGL-Registry/pull/591) that broke the GLEW build.

This change skips GL_MESA_sampler_objects for now.
