### PR TITLE
glew.pc.in tidy ups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,6 @@ tmp/$(SYSTEM)/default/shared/glew.o: src/glew.c include/GL/glew.h include/GL/wgl
 glew.pc: glew.pc.in
 	sed \
 		-e "s|@prefix@|$(GLEW_PREFIX)|g" \
-		-e "s|@libdir@|$(LIBDIR)|g" \
 		-e "s|@version@|$(GLEW_VERSION)|g" \
 		-e "s|@cflags@||g" \
 		-e "s|@libname@|$(NAME)|g" \

--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,6 @@ glew.pc: glew.pc.in
 	sed \
 		-e "s|@prefix@|$(GLEW_PREFIX)|g" \
 		-e "s|@libdir@|$(LIBDIR)|g" \
-		-e "s|@exec_prefix@|$(BINDIR)|g" \
-		-e "s|@includedir@|$(INCDIR)|g" \
 		-e "s|@version@|$(GLEW_VERSION)|g" \
 		-e "s|@cflags@||g" \
 		-e "s|@libname@|$(NAME)|g" \

--- a/glew.pc.in
+++ b/glew.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
 exec_prefix=${prefix}
-libdir=@libdir@
+libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
 Name: glew


### PR DESCRIPTION
- use exec_prefix/lib for libdir in glew.pc.in
- remove unused substitutions for glew.pc.in