### PR TITLE
Add INTERFACE definition GLEW_NO_GLU for glew_head.h

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -159,6 +159,7 @@ target_link_libraries (glew_s ${GLEW_LIBRARIES})
 
 target_compile_definitions(glew_s INTERFACE "GLEW_STATIC")
 foreach(t glew glew_s)
+  target_compile_definitions(${t} INTERFACE GLEW_NO_GLU)
   target_include_directories(${t} PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 endforeach()
 


### PR DESCRIPTION
Add public compile definitions to `glew-targets.cmake` for https://github.com/nigels-com/glew/blob/master/auto/src/glew_head.h#L1131

Fix https://github.com/microsoft/vcpkg/pull/43641#issuecomment-2639024494

Possible effects:

* https://github.com/colmap/colmap/issues/3144