### PR TITLE
gitea: On-prem Linux build coverage for gcc, clang, GLX, EGL and mingw cross-build

### DIFF
--- a/.gitea/workflows/linux-clang.yaml
+++ b/.gitea/workflows/linux-clang.yaml
@@ -1,5 +1,4 @@
 name: Ubuntu Linux clang Build
-run-name: ${{ gitea.actor }} is testing out Gitea Actions 🚀
 on: [push]
 
 jobs:

--- a/.gitea/workflows/linux-clang.yaml
+++ b/.gitea/workflows/linux-clang.yaml
@@ -1,0 +1,23 @@
+name: Ubuntu Linux clang Build
+run-name: ${{ gitea.actor }} is testing out Gitea Actions 🚀
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Dependencies
+        run: |
+          apt update
+          apt install -y clang libxmu-dev libxi-dev libgl-dev libegl1-mesa-dev dos2unix
+      - name: Git Checkout
+        uses: actions/checkout@v4
+      - name: Generate Code
+        run: |
+          make -C auto clobber
+          make extensions
+          make dist-src
+      - name: Build Binaries
+        run: |
+          make clean && SYSTEM=linux-clang      make
+          make clean && SYSTEM=linux-clang-egl  make

--- a/.gitea/workflows/linux-cmake.yaml
+++ b/.gitea/workflows/linux-cmake.yaml
@@ -1,5 +1,4 @@
 name: Ubuntu Linux cmake Build
-run-name: ${{ gitea.actor }} is testing out Gitea Actions 🚀
 on: [push]
 
 jobs:
@@ -17,10 +16,6 @@ jobs:
           "-DCMAKE_BUILD_TYPE=Release -DGLEW_X11=Y -DGLEW_EGL=N -DBUILD_SHARED_LIBS=Y",
           "-DCMAKE_BUILD_TYPE=Release -DGLEW_X11=N -DGLEW_EGL=Y -DBUILD_SHARED_LIBS=Y",
           ]
-    exclude:
-      - os: macos-latest
-        version: 12
-        environment: production
     steps:
       - name: Install Dependencies
         run: |

--- a/.gitea/workflows/linux-cmake.yaml
+++ b/.gitea/workflows/linux-cmake.yaml
@@ -1,0 +1,43 @@
+name: Ubuntu Linux cmake Build
+run-name: ${{ gitea.actor }} is testing out Gitea Actions 🚀
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flavour: [
+          "-DCMAKE_BUILD_TYPE=Debug -DGLEW_X11=Y -DGLEW_EGL=N -DBUILD_SHARED_LIBS=N",
+          "-DCMAKE_BUILD_TYPE=Debug -DGLEW_X11=N -DGLEW_EGL=Y -DBUILD_SHARED_LIBS=N",
+          "-DCMAKE_BUILD_TYPE=Debug -DGLEW_X11=Y -DGLEW_EGL=N -DBUILD_SHARED_LIBS=Y",
+          "-DCMAKE_BUILD_TYPE=Debug -DGLEW_X11=N -DGLEW_EGL=Y -DBUILD_SHARED_LIBS=Y",
+          "-DCMAKE_BUILD_TYPE=Release -DGLEW_X11=Y -DGLEW_EGL=N -DBUILD_SHARED_LIBS=N",
+          "-DCMAKE_BUILD_TYPE=Release -DGLEW_X11=N -DGLEW_EGL=Y -DBUILD_SHARED_LIBS=N",
+          "-DCMAKE_BUILD_TYPE=Release -DGLEW_X11=Y -DGLEW_EGL=N -DBUILD_SHARED_LIBS=Y",
+          "-DCMAKE_BUILD_TYPE=Release -DGLEW_X11=N -DGLEW_EGL=Y -DBUILD_SHARED_LIBS=Y",
+          ]
+    exclude:
+      - os: macos-latest
+        version: 12
+        environment: production
+    steps:
+      - name: Install Dependencies
+        run: |
+          apt update
+          apt install -y cmake ninja-build libxmu-dev libxi-dev libgl-dev libegl1-mesa-dev dos2unix
+      - name: Git Checkout
+        uses: actions/checkout@v4
+      - name: Generate Code
+        run: |
+          make -C auto clobber
+          make extensions
+          make dist-src
+      - name: Build Binaries
+        run: |
+          mkdir build_
+          cmake build/cmake -B build_ -G Ninja --fresh ${{ matrix.flavour }}
+          cmake --build build_
+          rm -Rf build_
+
+

--- a/.gitea/workflows/linux-gcc.yaml
+++ b/.gitea/workflows/linux-gcc.yaml
@@ -1,0 +1,23 @@
+name: Ubuntu Linux gcc Build
+run-name: ${{ gitea.actor }} is testing out Gitea Actions 🚀
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Dependencies
+        run: |
+          apt update
+          apt install -y libxmu-dev libxi-dev libgl-dev libegl1-mesa-dev dos2unix
+      - name: Git Checkout
+        uses: actions/checkout@v4
+      - name: Generate Code
+        run: |
+          make -C auto clobber
+          make extensions
+          make dist-src
+      - name: Build Binaries
+        run: |
+          make clean && SYSTEM=linux            make
+          make clean && SYSTEM=linux-egl        make

--- a/.gitea/workflows/linux-gcc.yaml
+++ b/.gitea/workflows/linux-gcc.yaml
@@ -1,5 +1,4 @@
 name: Ubuntu Linux gcc Build
-run-name: ${{ gitea.actor }} is testing out Gitea Actions 🚀
 on: [push]
 
 jobs:

--- a/.gitea/workflows/linux-mingw.yaml
+++ b/.gitea/workflows/linux-mingw.yaml
@@ -1,0 +1,23 @@
+name: Ubuntu Linux gcc cross-build
+run-name: ${{ gitea.actor }} is testing out Gitea Actions 🚀
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Dependencies
+        run: |
+          apt update
+          apt install -y mingw-w64 dos2unix
+      - name: Git Checkout
+        uses: actions/checkout@v4
+      - name: Generate Code
+        run: |
+          make -C auto clobber
+          make extensions
+          make dist-src
+      - name: Build Binaries
+        run: |
+          make clean && SYSTEM=linux-mingw32 make
+          make clean && SYSTEM=linux-mingw64 make

--- a/.gitea/workflows/linux-mingw.yaml
+++ b/.gitea/workflows/linux-mingw.yaml
@@ -1,5 +1,4 @@
 name: Ubuntu Linux gcc cross-build
-run-name: ${{ gitea.actor }} is testing out Gitea Actions 🚀
 on: [push]
 
 jobs:


### PR DESCRIPTION
Using [Gitea Actions](https://docs.gitea.com/usage/actions/overview) on-prem for now.