### PR TITLE
Experimental SYSTEM=Linux mingw64 clang

### DIFF
--- a/auto/src/glew_init_tail.c
+++ b/auto/src/glew_init_tail.c
@@ -66,3 +66,14 @@ int __stdcall DllMainCRTStartup(void* instance, unsigned reason, void* reserved)
   return 1;
 }
 #endif
+
+#if defined(_WIN32) && defined(GLEW_BUILD) && defined(__clang__)
+/* Windows mingw clang requires a DLL entry point */
+int __stdcall _DllMainCRTStartup(void* instance, unsigned reason, void* reserved)
+{
+  (void) instance;
+  (void) reason;
+  (void) reserved;
+  return 1;
+}
+#endif

--- a/config/Makefile.linux-mingw64-clang
+++ b/config/Makefile.linux-mingw64-clang
@@ -1,0 +1,24 @@
+# For cross-compiling from Linux to Windows 64-bit using mingw64
+# http://mingw-w64.org/
+#
+# Ubuntu/Debian:
+# $ sudo apt install mingw-w64
+# $ make SYSTEM=linux-mingw64
+
+NAME      := glew32
+HOST      := x86_64-w64-mingw32
+GLEW_DEST ?= /usr/local/$(HOST)
+CC    := $(HOST)-clang
+LD    := $(HOST)-ld
+LN    :=
+STRIP :=
+LDFLAGS.GL = -lopengl32 -lgdi32 -luser32 -lkernel32 -lmsvcrt
+CFLAGS.EXTRA  += -fno-stack-protector -Wno-cast-function-type
+WARN = -Wall -W
+POPT = -O2
+BIN.SUFFIX = .exe
+LIB.SONAME    = lib$(NAME).dll
+LIB.DEVLNK    = lib$(NAME).dll.a    # for mingw this is the dll import lib
+LIB.SHARED    = $(NAME).dll
+LIB.STATIC    = lib$(NAME).a        # the static lib will be broken
+LDFLAGS.SO    = -shared --out-implib lib/$(LIB.DEVLNK)

--- a/config/Makefile.linux-mingw64-clang
+++ b/config/Makefile.linux-mingw64-clang
@@ -1,9 +1,11 @@
-# For cross-compiling from Linux to Windows 64-bit using mingw64
-# http://mingw-w64.org/
+# For cross-compiling from Linux to Windows 64-bit using LLVM MinGW
+# https://github.com/mstorsjo/llvm-mingw
 #
 # Ubuntu/Debian:
-# $ sudo apt install mingw-w64
-# $ make SYSTEM=linux-mingw64
+# $ make SYSTEM=linux-mingw64-clang
+#
+# Note: It is likely necessary to configure LDFLAGS.GL to reflect the location
+#       of the Windows link libraries
 
 NAME      := glew32
 HOST      := x86_64-w64-mingw32
@@ -12,7 +14,7 @@ CC    := $(HOST)-clang
 LD    := $(HOST)-ld
 LN    :=
 STRIP :=
-LDFLAGS.GL = -lopengl32 -lgdi32 -luser32 -lkernel32 -lmsvcrt
+LDFLAGS.GL = -L/opt/llvm-mingw-20250613-msvcrt-ubuntu-22.04-x86_64/x86_64-w64-mingw32/lib -lopengl32 -lgdi32 -luser32 -lkernel32 -lmsvcrt
 CFLAGS.EXTRA  += -fno-stack-protector -Wno-cast-function-type
 WARN = -Wall -W
 POPT = -O2


### PR DESCRIPTION
In relation to Issue #410 I experimented with cross-building with the [mstorsjo/llvm-mingw](https://github.com/mstorsjo/llvm-mingw) clang mingw toolchain.

It seems successful, but I did not run the binaries on Windows since I don't have a Windows at the moment.

As it turns out there are actually _two_ options with this toolchain: 
* Universal CRT
* legacy msvcrt

I only tried the msvcrt one from:
[llvm-mingw 20250613 with LLVM 20.1.7](https://github.com/mstorsjo/llvm-mingw/releases/tag/20250613)

```
$ PATH=/opt/llvm-mingw-20250613-msvcrt-ubuntu-22.04-x86_64/bin:$PATH SYSTEM=linux-mingw64-clang make clean all
rm -f -r tmp/
rm -f -r lib/
rm -f -r bin/
rm -f glew.pc
mkdir lib
x86_64-w64-mingw32-clang -DGLEW_NO_GLU -DGLEW_BUILD -O2 -Wall -W -Iinclude -fno-stack-protector -Wno-cast-function-type  -o tmp/linux-mingw64-clang/default/shared/glew.o -c src/glew.c
x86_64-w64-mingw32-ld -shared --out-implib lib/libglew32.dll.a     -o lib/glew32.dll tmp/linux-mingw64-clang/default/shared/glew.o  -L/opt/llvm-mingw-20250613-msvcrt-ubuntu-22.04-x86_64/x86_64-w64-mingw32/lib -lopengl32 -lgdi32 -luser32 -lkernel32 -lmsvcrt 
sed \
	-e "s|@prefix@|/usr/local|g" \
	-e "s|@libdir@|/usr/local/x86_64-w64-mingw32/lib|g" \
	-e "s|@exec_prefix@|/usr/local/x86_64-w64-mingw32/bin|g" \
	-e "s|@includedir@|/usr/local/x86_64-w64-mingw32/include/GL|g" \
	-e "s|@version@|2.2.0|g" \
	-e "s|@cflags@||g" \
	-e "s|@libname@|glew32|g" \
	-e "s|@libgl@|-L/opt/llvm-mingw-20250613-msvcrt-ubuntu-22.04-x86_64/x86_64-w64-mingw32/lib -lopengl32 -lgdi32 -luser32 -lkernel32 -lmsvcrt|g" \
	-e "s|@requireslib@|glu|g" \
	< glew.pc.in > glew.pc
x86_64-w64-mingw32-clang -DGLEW_NO_GLU -DGLEW_STATIC -O2 -Wall -W -Iinclude -fno-stack-protector -Wno-cast-function-type  -o tmp/linux-mingw64-clang/default/static/glew.o -c src/glew.c
ar rv lib/libglew32.a tmp/linux-mingw64-clang/default/static/glew.o
ar: creating lib/libglew32.a
a - tmp/linux-mingw64-clang/default/static/glew.o
x86_64-w64-mingw32-clang -DGLEW_NO_GLU -O2 -Wall -W -Iinclude -fno-stack-protector -Wno-cast-function-type  -o tmp/linux-mingw64-clang/default/shared/glewinfo.o -c src/glewinfo.c
x86_64-w64-mingw32-clang -O2 -Wall -W -Iinclude -fno-stack-protector -Wno-cast-function-type -o bin/glewinfo.exe tmp/linux-mingw64-clang/default/shared/glewinfo.o -Llib  -lglew32  -L/opt/llvm-mingw-20250613-msvcrt-ubuntu-22.04-x86_64/x86_64-w64-mingw32/lib -lopengl32 -lgdi32 -luser32 -lkernel32 -lmsvcrt
x86_64-w64-mingw32-clang -DGLEW_NO_GLU -O2 -Wall -W -Iinclude -fno-stack-protector -Wno-cast-function-type  -o tmp/linux-mingw64-clang/default/shared/visualinfo.o -c src/visualinfo.c
x86_64-w64-mingw32-clang -O2 -Wall -W -Iinclude -fno-stack-protector -Wno-cast-function-type -o bin/visualinfo.exe tmp/linux-mingw64-clang/default/shared/visualinfo.o -Llib  -lglew32  -L/opt/llvm-mingw-20250613-msvcrt-ubuntu-22.04-x86_64/x86_64-w64-mingw32/lib -lopengl32 -lgdi32 -luser32 -lkernel32 -lmsvcrt
```

For some more context, Issue #157 also seems relevant to this.