### PR TITLE
Handle expanded tokens (revised)

### DIFF
--- a/auto/bin/make.pl
+++ b/auto/bin/make.pl
@@ -11,7 +11,7 @@ my %regex = (
     extname  => qr/^[A-Z][A-Za-z0-9_]+$/,
     exturl   => qr/^http.+$/,
     function => qr/^(.+) ([a-z][a-z0-9_]*) \((.*)\)$/i,
-    token    => qr/^([A-Z][A-Z0-9_x]*)\s+((?:0x)?[0-9A-Fa-f]+(u(ll)?)?|[A-Z][A-Z0-9_]*)$/,
+    token    => qr/^([A-Z][A-Za-z0-9_x]*)\s+((?:0x|-)?[0-9A-Fa-f]+(u(ll)?)?|[A-Z][A-Za-z0-9(),_-]*)$/,
     type     => qr/^typedef\s+(.+)$/,
     exact    => qr/.*;$/,
 );

--- a/auto/src/eglew_head.h
+++ b/auto/src/eglew_head.h
@@ -83,16 +83,4 @@ struct wl_buffer;
 struct wl_display;
 struct wl_resource;
 
-#define EGL_DONT_CARE                     ((EGLint)-1)
-
-#define EGL_NO_CONTEXT                    ((EGLContext)0)
-#define EGL_NO_DISPLAY                    ((EGLDisplay)0)
-#define EGL_NO_IMAGE                      ((EGLImage)0)
-#define EGL_NO_SURFACE                    ((EGLSurface)0)
-#define EGL_NO_SYNC                       ((EGLSync)0)
-
-#define EGL_UNKNOWN                       ((EGLint)-1)
-
-#define EGL_DEFAULT_DISPLAY               ((EGLNativeDisplayType)0)
-
 EGLAPI __eglMustCastToProperFunctionPointerType EGLAPIENTRY eglGetProcAddress (const char *procname);


### PR DESCRIPTION
Rebased and eglew.h migration for PR #371

```
160,170c160,163
< #define EGL_DONT_CARE                     ((EGLint)-1)
< 
< #define EGL_NO_CONTEXT                    ((EGLContext)0)
< #define EGL_NO_DISPLAY                    ((EGLDisplay)0)
< #define EGL_NO_IMAGE                      ((EGLImage)0)
< #define EGL_NO_SURFACE                    ((EGLSurface)0)
< #define EGL_NO_SYNC                       ((EGLSync)0)
< 
< #define EGL_UNKNOWN                       ((EGLint)-1)
< 
< #define EGL_DEFAULT_DISPLAY               ((EGLNativeDisplayType)0)
---
> /* Wayland types for WL_bind_wayland_display purposes */
> struct wl_buffer;
> struct wl_display;
> struct wl_resource;
177a171,174
> #define EGL_DONT_CARE EGL_CAST(EGLint,-1)
> #define EGL_NO_CONTEXT EGL_CAST(EGLContext,0)
> #define EGL_NO_DISPLAY EGL_CAST(EGLDisplay,0)
> #define EGL_NO_SURFACE EGL_CAST(EGLSurface,0)
324a322
> #define EGL_UNKNOWN EGL_CAST(EGLint,-1)
...
```
