### PR TITLE
Documentation: List GL_EXT_mesh_shader and others as newly supported in GLEW 2.3.0

### DIFF
--- a/auto/doc/log.html
+++ b/auto/doc/log.html
@@ -9,11 +9,17 @@
 <ul>
 <li> GL_ARM_shader_core_properties
 <li> GL_EXT_EGL_image_storage_compression
+<li> GL_EXT_fragment_shading_rate
 <li> GL_EXT_framebuffer_blit_layers
+<li> GL_EXT_mesh_shader
 <li> GL_EXT_separate_depth_stencil
 <li> GL_EXT_shader_clock
+<li> GL_EXT_shader_realtime_clock
 <li> GL_EXT_shader_samples_identical
+<li> GL_EXT_shader_texture_samples
 <li> GL_EXT_texture_storage_compression
+<li> GL_HUAWEI_program_binary
+<li> GL_HUAWEI_shader_binary
 <li> GL_IMG_pvric_end_to_end_signature
 <li> GL_IMG_tile_region_protection
 <li> GL_MESA_bgra
@@ -29,6 +35,7 @@
 <li> GL_QCOM_render_sRGB_R8_RG8
 <li> GL_QCOM_render_shared_exponent
 <li> GL_QCOM_shading_rate
+<li> GL_QCOM_texture_foveated2
 <li> GL_QCOM_texture_lod_bias
 <li> GL_QCOM_ycbcr_degamma
 <li> EGL_ANDROID_telemetry_hint


### PR DESCRIPTION
For issue #453