### PR TITLE
Cmake: Fix include directories for glew and glew_s targets

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -97,8 +97,6 @@ endif ()
 
 #### GLEW ####
 
-include_directories (${GLEW_DIR}/include ${X11_INCLUDE_DIR})
-
 set (GLEW_PUBLIC_HEADERS_FILES
   ${GLEW_DIR}/include/GL/wglew.h
   ${GLEW_DIR}/include/GL/glew.h
@@ -159,7 +157,11 @@ target_link_libraries (glew_s ${GLEW_LIBRARIES})
 
 target_compile_definitions(glew_s INTERFACE "GLEW_STATIC")
 foreach(t glew glew_s)
+  target_include_directories(${t} PUBLIC $<BUILD_INTERFACE:${GLEW_DIR}/include>)
   target_include_directories(${t} PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  if (NOT WIN32)
+    target_include_directories(${t} PUBLIC ${X11_INCLUDE_DIR})
+  endif()
 endforeach()
 
 set(targets_to_install "")


### PR DESCRIPTION
Although the include directory is added using the global `include_directories` command, when glew is added as a subproject using FetchContent or using `add_subdirectory`, the includes are not made available to the target that is linking glew or glew_s.

This fix ensures that projects using glew have actually access to glew's include directory.