### PR TITLE
GLhandleARB is void* for Apple, unsigned int for the rest (Issue #474)

### DIFF
--- a/auto/bin/make_header.pl
+++ b/auto/bin/make_header.pl
@@ -25,7 +25,7 @@ sub make_type($$)
 {
     my ($type) = @_;
 
-    if($type =~ /\bGLhandleARB\b/) {
+    if($type =~ /^\s*typedef\s+unsigned\s+int\s+GLhandleARB\s*$/) {
         return join("\n",
             "#ifdef __APPLE__",
             "typedef void *GLhandleARB;",

--- a/auto/bin/make_header.pl
+++ b/auto/bin/make_header.pl
@@ -23,7 +23,19 @@ sub make_define($$)
 # type declaration
 sub make_type($$)
 {
-    return "@_;"
+    my ($type) = @_;
+
+    if($type =~ /\bGLhandleARB\b/) {
+        return join("\n",
+            "#ifdef __APPLE__",
+            "typedef void *GLhandleARB;",
+            "#else",
+            "typedef unsigned int GLhandleARB;",
+            "#endif"
+        );
+    }
+
+    return "$type;"
 }
 
 sub make_exact($)


### PR DESCRIPTION
A fix to #474, by adding special check in `make_type` function in `make_header.pl`.
This fix keeps the definition of GLhandleARB in the right place.
Generated glew.h now looks like:
```
...
#define GL_OBJECT_ACTIVE_UNIFORM_MAX_LENGTH_ARB 0x8B87
#define GL_OBJECT_SHADER_SOURCE_LENGTH_ARB 0x8B88

typedef char GLcharARB;
#ifdef __APPLE__
typedef void *GLhandleARB;
#else
typedef unsigned int GLhandleARB;
#endif

typedef void (GLAPIENTRY * PFNGLATTACHOBJECTARBPROC) (GLhandleARB containerObj, GLhandleARB obj);
typedef void (GLAPIENTRY * PFNGLCOMPILESHADERARBPROC) (GLhandleARB shaderObj);
...
```
  
Overhead for additional check seems futile; following is my test result in my M2 Macbook Air.
```
In branch issue474            make  1.92s user 1.19s system 82% cpu 3.790 total
In branch apple-GLhandleARB   make  2.03s user 1.40s system 70% cpu 4.895 total 
```