### PR TITLE
fix: malloc NULL-check for obsolete Apple NSGLGetProcAddress path

### DIFF
--- a/auto/src/glew_head.c
+++ b/auto/src/glew_head.c
@@ -114,6 +114,10 @@ void* NSGLGetProcAddress (const GLubyte *name)
   }
   /* prepend a '_' for the Unix C symbol mangling convention */
   symbolName = malloc(strlen((const char*)name) + 2);
+  if (NULL == symbolName)
+  {
+    return NULL;
+  }
   strcpy(symbolName+1, (const char*)name);
   symbolName[0] = '_';
   symbol = NULL;


### PR DESCRIPTION
For Issue #480

See also: [Perlmint/glew-cmake PR #83](https://github.com/Perlmint/glew-cmake/pull/83/changes)

Note:  Mac OS X 10.3 Panther is circa 2003.